### PR TITLE
Fix the import task on very long key

### DIFF
--- a/Translation/Manager/TransUnitManager.php
+++ b/Translation/Manager/TransUnitManager.php
@@ -98,6 +98,7 @@ class TransUnitManager
      */
     public function findOneByKeyAndDomain($key, $domain)
     {
+        $key = substr($key, 0, 255);
         $fields = array(
             'key' => $key,
             'domain' => $domain,


### PR DESCRIPTION
I was importing translation files with `keys` longer 
than the 255 VARCHAR setted in the entity.

So the search was always returning false because searching with 
a long key something trimed at 255 chars fails.

That's not the most glorious fix, but the translations 
files I'm working with are not glorious neither. I think 
a 255 chars key is enougth, this PR is only about 
making the imported works with bad translation files.
