### PR TITLE
session compatibility with symfony 2.3

### DIFF
--- a/Controller/EditionController.php
+++ b/Controller/EditionController.php
@@ -2,9 +2,8 @@
 
 namespace Lexik\Bundle\TranslationBundle\Controller;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -65,6 +64,7 @@ class EditionController extends Controller
     /**
      * Update a trans unit element from the javascript grid.
      *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function updateAction()
@@ -113,7 +113,10 @@ class EditionController extends Controller
     {
         $this->get('translator')->removeLocalesCacheFiles($this->getManagedLocales());
 
-        $this->get('session')->setFlash('success', $this->get('translator')->trans('translations.cache_removed', array(), 'LexikTranslationBundle'));
+        /** @var $session Session */
+        $session = $this->get('session');
+
+        $session->getFlashBag()->set('success', $this->get('translator')->trans('translations.cache_removed', array(), 'LexikTranslationBundle'));
 
         return $this->redirect($this->generateUrl('lexik_translation_grid'));
     }

--- a/Resources/views/Edition/grid.html.twig
+++ b/Resources/views/Edition/grid.html.twig
@@ -11,9 +11,10 @@
 {% endblock %}
 
 {% block content %}
-{% if app.session.flashbag.has('sucess') %}
-<span>{{ app.session.flashbag.get('sucess') }}</span>
-{% endif %}
+
+{% for flashMessage in app.session.flashbag.get('success') %}
+	<span>{{ flashMessage }}</span>
+{% endfor %}
 
 <div>
     <a href="{{ path('lexik_translation_new') }}" role="button" class="ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary">

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -6,8 +6,6 @@ use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Session;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Config\ConfigCache;
 
 /**
@@ -116,6 +114,7 @@ class Translator extends BaseTranslator
      * Returns a loader according to the given format.
      *
      * @param string $format
+     * @throws \RuntimeException
      * @return LoaderInterface
      */
     public function getLoader($format)


### PR DESCRIPTION
In symfony 2.1 the session has been refactored and should be used via the flashbag introduced. The old behavior will be removed in 2.3 and is currently considered deprecated.

Reference: https://github.com/symfony/symfony/blob/master/UPGRADE-2.1.md#session

This commit will BC with symfony 2.0.
