### PR TITLE
save when switching to another row

### DIFF
--- a/Resources/views/Edition/grid.html.twig
+++ b/Resources/views/Edition/grid.html.twig
@@ -88,7 +88,7 @@ $(document).ready(function() {
         sortorder: "asc",
         onSelectRow: function(id) {
             if(id && id !== lastSelected) {
-                jQuery('#trans-grid').jqGrid("restoreRow", lastSelected);
+                jQuery('#trans-grid').jqGrid("saveRow", lastSelected);
                 jQuery('#trans-grid').jqGrid("editRow", id, true);
                 lastSelected = id;
             }


### PR DESCRIPTION
I know "restoreRow" is suggested in their wiki, but saveRow makes more sense (IMO). 
