### PR TITLE
[Bugfix] Fixed "file=null"-bug when exporting new translations

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -49,6 +49,8 @@
         <!-- Managers -->
         <service id="lexik_translation.trans_unit.manager" class="%lexik_translation.trans_unit.manager.class%">
             <argument type="service" id="lexik_translation.translation_storage" />
+            <argument type="service" id="lexik_translation.file.manager" />
+            <argument>%kernel.root_dir%</argument>
         </service>
         
         <service id="lexik_translation.file.manager" class="%lexik_translation.file.manager.class%">


### PR DESCRIPTION
Awesome bundle, really. I found a bug though... 
### To reproduce error

My default language is "sv" and i support translations on "sv" and "en". 

``` yaml
//messages.sv.yml
a: "foo_sv"
b: "bar_sv"
c: "baz_sv"
```

``` yaml
//messages.en.yml
a: "foo"
b: "bar"
```

Run the input command. Add the missing translation with key "c" (Do not use the "new translation" link). Run the export command. 

**Result** 

``` yaml
//messages.en.yml
a: "foo"
b: "bar"
```

**Expected result**

``` yaml
//messages.en.yml
a: "foo"
b: "bar"
c: "baz"
```
### The problem

The translation row in the database do not get a file property. (file_id = null). 

This PR solves that issue by looking for an other Translation object by the same TransUnit and get the file from there. 
