### PR TITLE
[Feature] Add support for yml tree

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -88,6 +88,10 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
 
+                ->booleanNode('use_yml_tree')
+                    ->defaultValue(false)
+                ->end()
+
             ->end()
         ;
 

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -41,6 +41,7 @@ class LexikTranslationExtension extends Extension
         $container->setParameter('lexik_translation.storage', $config['storage']);
         $container->setParameter('lexik_translation.base_layout', $config['base_layout']);
         $container->setParameter('lexik_translation.grid_input_type', $config['grid_input_type']);
+        $container->setParameter('lexik_translation.use_yml_tree', $config['use_yml_tree']);
 
         $this->buildTranslationStorageDefinition($container, $config['storage']['type'], isset($config['storage']['object_manager'])?$config['storage']['object_manager']:null);
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -72,6 +72,7 @@
         </service>
         
         <service id="lexik_translation.exporter.yml" class="%lexik_translation.exporter.yml.class%">
+            <argument>%lexik_translation.use_yml_tree%</argument>
             <tag name="lexik_translation.exporter" alias="yml" />
         </service>
         

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -49,6 +49,7 @@ Additional configuration options (default values are shown here):
 # app/config/config.yml
 lexik_translation:
     base_layout:      "LexikTranslationBundle::layout.html.twig"   # layout used with the translation edition template
+    use_yml_tree: false                                    # if "true" we will print a nice tree in the yml source files. It is a little slower.
     storage:
         type: orm                                          # where to store translations: "orm" or "mongodb"
         object_manager: something                          # The name of the entity / document manager which uses different connection (see: http://symfony.com/doc/current/cookbook/doctrine/multiple_entity_managers.html)

--- a/Tests/Unit/Translation/Exporter/YamlExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/YamlExporterTest.php
@@ -50,4 +50,101 @@ key.c: ccc
 C;
         $this->assertEquals($expectedContent, file_get_contents($outFile));
     }
+    /**
+     * @group exporter
+     */
+    public function testCreateMultiArray()
+    {
+        $exporter = new TmpExporter();
+
+        $result=$exporter->createMultiArray(array('foo.bar.baz'=>'foobar'));
+        $expected=array('foo'=>array('bar'=>array('baz'=>'foobar')));
+        $this->assertEquals($expected, $result);
+
+        $result=$exporter->createMultiArray(array(
+                'foo.bar.baz'=>'foobar',
+                'foo.foobaz'=>'bazbar',
+            ));
+        $expected=array('foo'=>array(
+            'foobaz'=>'bazbar',
+            'bar'=>array('baz'=>'foobar'),
+        ));
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @group exporter
+     */
+    public function testflattenArray()
+    {
+        $exporter = new TmpExporter();
+
+        $result=$exporter->flattenArray(array('foo'=>array('bar'=>array('baz'=>'foobar'))));
+        $expected=array('foo.bar.baz'=>'foobar');
+        $this->assertEquals($expected, $result);
+
+        $result=$exporter->flattenArray(
+            array('bundle'=>
+                array('foo'=>
+                    array(
+                        'foobaz'=>'bazbar',
+                        'bar'=>
+                            array(
+                                'baz0'=>'foobar',
+                                'baz1'=>'foobaz',
+                            ),
+                    )
+                )
+            )
+        );
+        $expected=array('bundle.foo'=>
+            array(
+                'foobaz'=>'bazbar',
+                'bar'=>
+                    array(
+                        'baz0'=>'foobar',
+                        'baz1'=>'foobaz',
+                    ),
+            )
+        );
+        $this->assertEquals($expected, $result);
+
+        $result=$exporter->flattenArray(
+            array('bundle'=>
+                array('foo'=>
+                    array(
+                        'foobaz'=>'bazbar',
+                        'bar'=>array('baz'=>'foobar'),
+                    )
+                )
+            )
+        );
+        $expected=array('bundle.foo'=>
+            array(
+                'foobaz'=>'bazbar',
+                'bar'=>array('baz'=>'foobar'),
+            )
+        );
+        $this->assertEquals($expected, $result);
+    }
+}
+
+/**
+ * Class TmpExporter
+ *
+ * @author Tobias Nyholm
+ *
+ * Use this class to exploit protected functions
+ */
+class TmpExporter extends YamlExporter
+{
+    public function createMultiArray(array $translations)
+    {
+        return parent::createMultiArray($translations);
+    }
+
+    public function flattenArray($array, $prefix='')
+    {
+        return parent::flattenArray($array, $prefix);
+    }
 }

--- a/Translation/Exporter/YamlExporter.php
+++ b/Translation/Exporter/YamlExporter.php
@@ -8,20 +8,125 @@ use Symfony\Component\Yaml\Dumper;
  * Export translations to a Yaml file.
  *
  * @author Cédric Girard <c.girard@lexik.fr>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
 class YamlExporter implements ExporterInterface
 {
+    private $createTree;
+
+    /**
+     * @param bool $createTree
+     */
+    public function __construct($createTree=false)
+    {
+        $this->createTree = $createTree;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function export($file, $translations)
     {
+        if ($this->createTree) {
+            $result=$this->createMultiArray($translations);
+            $translations=$this->flattenArray($result);
+        }
+
         $ymlDumper = new Dumper();
-        $ymlContent = $ymlDumper->dump($translations, 1);
+        $ymlDumper->setIndentation(2);
+        $ymlContent = $ymlDumper->dump($translations,10);
 
         $bytes = file_put_contents($file, $ymlContent);
 
         return ($bytes !== false);
+    }
+
+    /**
+     * Create a multi dimension array.
+     *
+     * If you got a array like array('foo.bar.baz'=>'foobar') we will create an array like:
+     * array('foo'=>array('bar'=>array('baz'=>'foobar')))
+     *
+     * @param array $translations
+     *
+     * @return array
+     */
+    protected function createMultiArray(array $translations)
+    {
+        $res=array();
+
+        foreach($translations as $keyString=>$value) {
+            $keys=explode('.',$keyString);
+
+            //$keyString might be "Hello world."
+            $keyLength = count($keys);
+            if ($keys[$keyLength-1]=='') {
+                unset($keys[$keyLength-1]);
+                $keys[$keyLength-2].='.';
+            }
+
+            $this->addValueToMultiArray($res, $value, $keys);
+        }
+
+        return $res;
+    }
+
+	/**
+     * 
+     *
+     * @param array $array
+     * @param $value
+     * @param array $keys
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function addValueToMultiArray(array &$array, $value, array $keys)
+    {
+        $key=array_shift($keys);
+
+        //base case
+        if (count($keys)==0) {
+            $array[$key]=$value;
+
+            return;
+        }
+
+        if (!isset($array[$key])) {
+            $array[$key]=array();
+        }
+        elseif(!is_array($array[$key])){
+            //if $array[$key] isset but is not array
+            throw new \InvalidArgumentException('Found an leaf, expected a tree');
+        }
+
+        $this->addValueToMultiArray($array[$key], $value, $keys);
+    }
+
+    /**
+     * Make sure we flatten the array in the begnning to make a lower tree
+     *
+     * @param mixed $array
+     * @param string $prefix
+     *
+     * @return mixed
+     */
+    protected  function flattenArray($array, $prefix='')
+    {
+        if (is_array($array)){
+            foreach ($array as $key=>$subarray) {
+                if (count($array)==1) {
+                    return $this->flattenArray($subarray, ($prefix==''?$prefix:$prefix.'.').$key);
+                }
+
+                $array[$key]=$this->flattenArray($subarray);
+            }
+        }
+
+        if ($prefix=='') {
+            return $array;
+        }
+
+        return array($prefix=>$array);
     }
 
     /**


### PR DESCRIPTION
This PR adds an option to export the YML like a tree. 
This feature is disabled by default.
#### Before

``` yaml
foo.bar.baz: "foobar"
foo.bar.foo: "test"
foo.baz: "Bazbar"
```
#### After

``` yaml
foo:
  bar:
    baz: "foobar"
    foo: "test"
  baz: "Bazbar"
```
