### PR TITLE
Change remove cache file behavior

### DIFF
--- a/Tests/Unit/Translation/TranslatorTest.php
+++ b/Tests/Unit/Translation/TranslatorTest.php
@@ -55,9 +55,15 @@ class TranslatorTest extends BaseUnitTestCase
         // remove locale 'fr'
         $this->assertTrue(file_exists($cacheDir.'/catalogue.fr.php'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.fr.php.meta'));
+        $this->assertTrue(file_exists($cacheDir.'/catalogue.fr_FR.php'));
+        $this->assertTrue(file_exists($cacheDir.'/catalogue.fr_FR.php.meta'));
+
         $translator->removeCacheFile('fr');
+
         $this->assertFalse(file_exists($cacheDir.'/catalogue.fr.php'));
         $this->assertFalse(file_exists($cacheDir.'/catalogue.fr.php.meta'));
+        $this->assertFalse(file_exists($cacheDir.'/catalogue.fr_FR.php'));
+        $this->assertFalse(file_exists($cacheDir.'/catalogue.fr_FR.php.meta'));
 
         // remove locale 'en'
         $this->assertTrue(file_exists($cacheDir.'/catalogue.en.php'));
@@ -80,6 +86,8 @@ class TranslatorTest extends BaseUnitTestCase
         $this->assertTrue(file_exists($cacheDir.'/database.resources.php.meta'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.fr.php'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.fr.php.meta'));
+        $this->assertTrue(file_exists($cacheDir.'/catalogue.fr_FR.php'));
+        $this->assertTrue(file_exists($cacheDir.'/catalogue.fr_FR.php.meta'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.en.php'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.en.php.meta'));
 
@@ -89,6 +97,8 @@ class TranslatorTest extends BaseUnitTestCase
         $this->assertFalse(file_exists($cacheDir.'/database.resources.php.meta'));
         $this->assertFalse(file_exists($cacheDir.'/catalogue.fr.php'));
         $this->assertFalse(file_exists($cacheDir.'/catalogue.fr.php.meta'));
+        $this->assertFalse(file_exists($cacheDir.'/catalogue.fr_FR.php'));
+        $this->assertFalse(file_exists($cacheDir.'/catalogue.fr_FR.php.meta'));
         $this->assertFalse(file_exists($cacheDir.'/catalogue.en.php'));
         $this->assertFalse(file_exists($cacheDir.'/catalogue.en.php.meta'));
     }
@@ -115,6 +125,9 @@ class TranslatorTest extends BaseUnitTestCase
 
         touch($cacheDir.'/catalogue.fr.php');
         touch($cacheDir.'/catalogue.fr.php.meta');
+        
+        touch($cacheDir.'/catalogue.fr_FR.php');
+        touch($cacheDir.'/catalogue.fr_FR.php.meta');
 
         touch($cacheDir.'/catalogue.en.php');
         touch($cacheDir.'/catalogue.en.php.meta');

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -52,16 +52,19 @@ class Translator extends BaseTranslator
      */
     public function removeCacheFile($locale)
     {
-        $file = sprintf('%s/catalogue.%s.php', $this->options['cache_dir'], $locale);
-        $deleted = false;
+        $localeExploded = explode('_', $locale);
+        $localePattern = sprintf('%s/catalogue.*%s*.php', $this->options['cache_dir'], $localeExploded[0]);
+        $files = glob($localePattern);
 
-        if (file_exists($file)) {
-            $deleted = unlink($file);
-        }
-
-        $metadata = $file.'.meta';
-        if (file_exists($metadata)) {
-            unlink($metadata);
+        $deleted = true;
+        foreach ($files as $file) {
+            if (!unlink($file)) {
+                $deleted = false;
+            }
+            $metadata = $file.'.meta';
+            if (file_exists($metadata)) {
+                unlink($metadata);
+            }
         }
 
         return $deleted;


### PR DESCRIPTION
Use case:

We have "fr" and "en" in our manage locales. In some case, our user have fr, fr_FR, en, en_US as locale, therefore when Symfony generates the translation cache, there are 4 different "locales" that are created. The translation editor has only "fr" and "en" resource since they are the only manage locales. When invalidating cache, only catalogue.fr.php and catalogue.en.php are removed, which is not the desired behavior since we want catalogue.fr_FR.php and catalogue.en_US.php to be removed accordingly.

Therefore, I think it should be safe to remove cache files by regex pattern and in the worst case, the cache will be regenerated during the next request.
