### PR TITLE
Fixing MongoId::$id error

### DIFF
--- a/Util/DataGrid/DataGridFormatter.php
+++ b/Util/DataGrid/DataGridFormatter.php
@@ -93,7 +93,7 @@ class DataGridFormatter
         }
 
         $formatted = array(
-            'id'     => ('mongodb' == $this->storage) ? $transUnit['_id']->id : $transUnit['id'],
+            'id'     => ('mongodb' == $this->storage) ? $transUnit['_id']->{'$id'} : $transUnit['id'],
             'domain' => $transUnit['domain'],
             'key'    => $transUnit['key'],
         );


### PR DESCRIPTION
Fixing error : 
\vendor\lexik\translation-bundle\Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridFormatter.php line 96

The MongoId $id field starts with a dollar sign so you may have to call it by {'$id'}, else PHP won't parse it correctly.
