### PR TITLE
skip empty translation values in import command

### DIFF
--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -70,7 +70,7 @@ class FileImporter
             $translationFile = $this->fileManager->getFor($file->getFilename(), $file->getPath());
 
             foreach ($messageCatalogue->all($domain) as $key => $content) {
-				//skip empty translation values
+		//skip empty translation values
                 if(!isset($content)){
                     continue;
                 }


### PR DESCRIPTION
To avoid the below scenario using MongoDB as database
1 - Run import command on translation files that have some values empty 
2 - It will be inserted in database without errors 
3 -  undefined index content error will be produced while using dataGrid 
