### PR TITLE
fixed special chars issue in translations and prevent error when tables ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .settings
 vendor
 composer.lock
+.idea

--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -22,6 +22,11 @@ class TransUnitRepository extends EntityRepository
      */
     public function getAllDomainsByLocale()
     {
+        $schemaManager = $this->getEntityManager()->getConnection()->getSchemaManager();
+        $tableName = $this->getClassMetadata()->getTableName();
+        if (!$schemaManager->tablesExist(array($tableName))) {
+            return array();
+        }
         return $this->createQueryBuilder('tu')
             ->select('te.locale, tu.domain')
             ->leftJoin('tu.translations', 'te')

--- a/Resources/public/js/translation.js
+++ b/Resources/public/js/translation.js
@@ -133,7 +133,7 @@ app.directive('editableRow', ['$http', 'sharedMessage', function ($http, sharedM
 
                     var parameters = [];
                     for (var name in $scope.translation) {
-                        parameters.push(name+'='+$scope.translation[name]);
+                        parameters.push(name+'='+encodeURIComponent($scope.translation[name]));
                     }
 
                     // force content type to make SF create a Request with the PUT parameters


### PR DESCRIPTION
In some special situations, e.g. "Terms & conditions" translation was truncated to first occurrence of special char. encodeURIComponent function solved this problem.

On cache:clear command, when tables weren't exist, there was an error and deploy via capifony was hard to accomplish.
