### PR TITLE
This modification is designed to fix a bug for orm storage

### DIFF
--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -168,8 +168,8 @@ class DoctrineORMStorage implements StorageInterface
     public function translationsTablesExist()
     {
         $tables = array(
-            $this->em->getClassMetadata($this->getModelClass('trans_unit')),
-            $this->em->getClassMetadata($this->getModelClass('translation'))
+            $this->em->getClassMetadata($this->getModelClass('trans_unit'))->table['name'],
+            $this->em->getClassMetadata($this->getModelClass('translation'))->table['name']
         );
 
         $schemaManager = $this->em->getConnection()->getSchemaManager();


### PR DESCRIPTION
For ORM storages, the tablesExist method will return false everytime because the array passed as parameters should only contain table names instead of the whole structure. Otherwise it will use the ClassMetaDataInfo's __toString method which will not always return the table's name.
