### PR TITLE
Implemented propel storage backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor
 composer.lock
+Propel/map
+Propel/om
+

--- a/Command/ExportTranslationsCommand.php
+++ b/Command/ExportTranslationsCommand.php
@@ -2,13 +2,12 @@
 
 namespace Lexik\Bundle\TranslationBundle\Command;
 
-use Lexik\Bundle\TranslationBundle\Model\File;
-
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
 
 /**
  * Export translations from the database in to files.
@@ -79,7 +78,7 @@ class ExportTranslationsCommand extends ContainerAwareCommand
      *
      * @param File $file
      */
-    protected function exportFile(File $file)
+    protected function exportFile(FileInterface $file)
     {
         $rootDir = $this->getContainer()->getParameter('kernel.root_dir');
 
@@ -109,7 +108,7 @@ class ExportTranslationsCommand extends ContainerAwareCommand
     /**
      * If the output file exists we merge existing translations with those from the database.
      *
-     * @param File $file
+     * @param FileInterface $file
      * @param string $outputFile
      * @param array $translations
      * @return array

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('lexik_translation');
 
-        $storages = array('orm', 'mongodb');
+        $storages = array('orm', 'mongodb', 'propel');
         $registrationTypes = array('all', 'files', 'database');
         $inputTypes = array('text', 'textarea');
 

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -73,6 +73,13 @@ class LexikTranslationExtension extends Extension
             } else {
                 $objectManagerReference = new Reference('doctrine.odm.mongodb.document_manager');
             }
+        } else if ('propel' == $storage) {
+            // In the Propel case the object_manager setting is used for the connection name
+            if(isset($objectManager)){
+                $objectManagerReference = $objectManager;
+            } else {
+                $objectManagerReference = null;
+            }
         } else {
             throw new \RuntimeException(sprintf('Unsupported storage "%s".', $storage));
         }

--- a/Document/File.php
+++ b/Document/File.php
@@ -3,11 +3,12 @@
 namespace Lexik\Bundle\TranslationBundle\Document;
 
 use Lexik\Bundle\TranslationBundle\Model\File as FileModel;
+use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class File extends FileModel
+class File extends FileModel implements FileInterface
 {
     /**
      * {@inheritdoc}

--- a/Document/TransUnit.php
+++ b/Document/TransUnit.php
@@ -3,11 +3,12 @@
 namespace Lexik\Bundle\TranslationBundle\Document;
 
 use Lexik\Bundle\TranslationBundle\Model\TransUnit as TransUnitModel;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class TransUnit extends TransUnitModel
+class TransUnit extends TransUnitModel implements TransUnitInterface
 {
     /**
      * Convert all MongoTimestamp object to time.

--- a/Document/Translation.php
+++ b/Document/Translation.php
@@ -3,11 +3,12 @@
 namespace Lexik\Bundle\TranslationBundle\Document;
 
 use Lexik\Bundle\TranslationBundle\Model\Translation as TranslationModel;
+use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class Translation extends TranslationModel
+class Translation extends TranslationModel implements TranslationInterface
 {
     /**
      * Convert all MongoTimestamp object to time.

--- a/Entity/File.php
+++ b/Entity/File.php
@@ -5,13 +5,14 @@ namespace Lexik\Bundle\TranslationBundle\Entity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 use Lexik\Bundle\TranslationBundle\Model\File as FileModel;
+use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
 
 /**
  * @UniqueEntity(fields={"hash"})
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class File extends FileModel
+class File extends FileModel implements FileInterface
 {
     /**
      * {@inheritdoc}

--- a/Entity/TransUnit.php
+++ b/Entity/TransUnit.php
@@ -5,13 +5,14 @@ namespace Lexik\Bundle\TranslationBundle\Entity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 use Lexik\Bundle\TranslationBundle\Model\TransUnit as TransUnitModel;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 
 /**
  * @UniqueEntity(fields={"key", "domain"})
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class TransUnit extends TransUnitModel
+class TransUnit extends TransUnitModel implements TransUnitInterface
 {
     /**
      * Add translations

--- a/Entity/Translation.php
+++ b/Entity/Translation.php
@@ -5,13 +5,14 @@ namespace Lexik\Bundle\TranslationBundle\Entity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 use Lexik\Bundle\TranslationBundle\Model\Translation as TranslationModel;
+use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
 
 /**
  * @UniqueEntity(fields={"transUnit", "locale"})
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class Translation extends TranslationModel
+class Translation extends TranslationModel implements TranslationInterface
 {
     /**
      * @var int

--- a/Form/Handler/TransUnitFormHandler.php
+++ b/Form/Handler/TransUnitFormHandler.php
@@ -3,9 +3,10 @@
 namespace Lexik\Bundle\TranslationBundle\Form\Handler;
 
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitManagerInterface;
+use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
 use Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
-use Lexik\Bundle\TranslationBundle\Model\File;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnit as PropelTransUnit;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -98,10 +99,15 @@ class TransUnitFormHandler implements FormHandlerInterface
                             $this->rootDir.'/Resources/translations'
                         );
 
-                        if ($file instanceof File) {
+                        if ($file instanceof FileInterface) {
                             $translation->setFile($file);
                         }
                     }
+                }
+
+                if ($transUnit instanceof PropelTransUnit) {
+                    // The setTranslations() method only accepts PropelCollections
+                    $translations = new \PropelObjectCollection($translations);
                 }
 
                 $transUnit->setTranslations($translations);

--- a/Manager/FileInterface.php
+++ b/Manager/FileInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Manager;
+
+/**
+ * File interface.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+interface FileInterface
+{
+}

--- a/Manager/FileManager.php
+++ b/Manager/FileManager.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\TranslationBundle\Manager;
 
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
-use Lexik\Bundle\TranslationBundle\Model\File;
 
 use Doctrine\Common\Persistence\ObjectManager;
 
@@ -45,7 +44,7 @@ class FileManager implements FileManagerInterface
         $hash = $this->generateHash($name, $this->getFileRelativePath($path));
         $file = $this->storage->getFileByHash($hash);
 
-        if (!($file instanceof File)) {
+        if (!($file instanceof FileInterface)) {
             $file = $this->create($name, $path);
         }
 

--- a/Manager/TransUnitInterface.php
+++ b/Manager/TransUnitInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Manager;
+
+/**
+ * TransUnit manager interface.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+interface TransUnitInterface
+{
+    public function getTranslations();
+
+    public function hasTranslation($locale);
+
+    public function getTranslation($locale);
+
+    public function setKey($key);
+
+    public function setDomain($domain);
+}

--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -3,9 +3,6 @@
 namespace Lexik\Bundle\TranslationBundle\Manager;
 
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
-use Lexik\Bundle\TranslationBundle\Model\File;
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
-use Lexik\Bundle\TranslationBundle\Model\Translation;
 
 /**
  * Class to manage TransUnit entities or documents.
@@ -84,7 +81,7 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function addTranslation(TransUnit $transUnit, $locale, $content, File $file = null, $flush = false)
+    public function addTranslation(TransUnitInterface $transUnit, $locale, $content, FileInterface $file = null, $flush = false)
     {
         $translation = null;
 
@@ -114,7 +111,7 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function updateTranslation(TransUnit $transUnit, $locale, $content, $flush = false)
+    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false)
     {
         $translation = null;
         $i = 0;
@@ -141,7 +138,7 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function updateTranslationsContent(TransUnit $transUnit, array $translations, $flush = false)
+    public function updateTranslationsContent(TransUnitInterface $transUnit, array $translations, $flush = false)
     {
         foreach ($translations as $locale => $content) {
             if (!empty($content)) {
@@ -163,12 +160,12 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * Get the proper File for this TransUnit and locale
      *
-     * @param TransUnit $transUnit
+     * @param TransUnitInterface $transUnit
      * @param string $locale
      *
-     * @return File|null
+     * @return FileInterface|null
      */
-    protected function getTranslationFile(TransUnit &$transUnit, $locale)
+    protected function getTranslationFile(TransUnitInterface &$transUnit, $locale)
     {
         $file=null;
         foreach ($transUnit->getTranslations() as $translationModel) {

--- a/Manager/TransUnitManagerInterface.php
+++ b/Manager/TransUnitManagerInterface.php
@@ -2,10 +2,6 @@
 
 namespace Lexik\Bundle\TranslationBundle\Manager;
 
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
-use Lexik\Bundle\TranslationBundle\Model\Translation;
-use Lexik\Bundle\TranslationBundle\Model\File;
-
 /**
  * TransUnit manager interface.
  *
@@ -17,7 +13,7 @@ interface TransUnitManagerInterface
      * Returns a new TransUnit instance with new translations for each $locales.
      *
      * @param array $locales
-     * @return TransUnit
+     * @return TransUnitInterface
      */
     public function newInstance($locales = array());
 
@@ -27,39 +23,39 @@ interface TransUnitManagerInterface
      * @param string  $keyName
      * @param string  $domainName
      * @param boolean $flush
-     * @return TransUnit
+     * @return TransUnitInterface
      */
     public function create($keyName, $domainName, $flush = false);
 
     /**
      * Add a new translation to the given trans unit.
      *
-     * @param TransUnit $transUnit
-     * @param string    $locale
-     * @param string    $content
-     * @param File      $file
-     * @param boolean   $flush
-     * @return Translation
+     * @param TransUnitInterface    $transUnit
+     * @param string                $locale
+     * @param string                $content
+     * @param FileInterface         $file
+     * @param boolean               $flush
+     * @return TranslationInterface
      */
-    public function addTranslation(TransUnit $transUnit, $locale, $content, File $file = null, $flush = false);
+    public function addTranslation(TransUnitInterface $transUnit, $locale, $content, FileInterface $file = null, $flush = false);
 
     /**
      * Update the translated content of a trans unit for the given locale.
      *
-     * @param TransUnit $transUnit
-     * @param string    $locale
-     * @param string    $content
-     * @param boolean   $flush
-     * @return Translation
+     * @param TransUnitInterface    $transUnit
+     * @param string                $locale
+     * @param string                $content
+     * @param boolean               $flush
+     * @return TranslationInterface
      */
-    public function updateTranslation(TransUnit $transUnit, $locale, $content, $flush = false);
+    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false);
 
     /**
      * Update the content of each translations for the given trans unit.
      *
-     * @param TransUnit $transUnit
-     * @param array     $translations
-     * @param boolean   $flush
+     * @param TransUnitInterface    $transUnit
+     * @param array                 $translations
+     * @param boolean               $flush
      */
-    public function updateTranslationsContent(TransUnit $transUnit, array $translations, $flush = false);
+    public function updateTranslationsContent(TransUnitInterface $transUnit, array $translations, $flush = false);
 }

--- a/Manager/TranslationInterface.php
+++ b/Manager/TranslationInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Manager;
+
+/**
+ * Translation interface.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+interface TranslationInterface
+{
+    /**
+     * @return string
+     */
+    public function getLocale();
+
+    /**
+     * @return string
+     */
+    public function getContent();
+}

--- a/Propel/File.php
+++ b/Propel/File.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseFile;
+use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
+
+class File extends BaseFile implements FileInterface
+{
+    /**
+     * Set file name
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        list($domain, $locale, $extention) = explode('.', $name);
+
+        $this
+            ->setDomain($domain)
+            ->setLocale($locale)
+            ->setExtention($extention)
+        ;
+
+        return $this;
+    }
+
+    /**
+     * Get file name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return sprintf('%s.%s.%s', $this->getDomain(), $this->getLocale(), $this->getExtention());
+    }
+}

--- a/Propel/FilePeer.php
+++ b/Propel/FilePeer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseFilePeer;
+
+class FilePeer extends BaseFilePeer
+{
+}

--- a/Propel/FileQuery.php
+++ b/Propel/FileQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseFileQuery;
+
+class FileQuery extends BaseFileQuery
+{
+}

--- a/Propel/FileRepository.php
+++ b/Propel/FileRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+/**
+ * Repository for TransUnit entity.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class FileRepository
+{
+    /**
+     * @var \PDO
+     */
+    protected $connection;
+
+    public function __construct(\PDO $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return PDO
+     */
+    protected function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Returns all files matching a given locale and a given domains.
+     *
+     * @param array $locales
+     * @param array $domains
+     * @return array
+     */
+    public function findForLocalesAndDomains(array $locales, array $domains)
+    {
+        return FileQuery::create()
+            ->_if(count($locales) > 0)
+                ->filterByLocale($locales, \Criteria::IN)
+            ->_endif()
+
+            ->_if(count($domains) > 0)
+                ->filterByDomain($domains, \Criteria::IN)
+            ->_endif()
+
+            ->find($this->getConnection())
+        ;
+    }
+}

--- a/Propel/TransUnit.php
+++ b/Propel/TransUnit.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTransUnit;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
+use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
+
+class TransUnit extends BaseTransUnit implements TransUnitInterface
+{
+    protected $translations = array();
+
+    /**
+     * Return translations with  not blank content.
+     *
+     * @return array
+     */
+    public function filterNotBlankTranslations()
+    {
+        return array_filter($this->getTranslations()->getArrayCopy(), function ($translation) {
+            $content = $translation->getContent();
+
+            return !empty($content);
+        });
+    }
+
+    /** (non-PHPdoc)
+     * @see \Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface::hasTranslation()
+     */
+    public function hasTranslation($locale)
+    {
+        return null !== $this->getTranslation($locale);
+    }
+
+    /**
+     * Return the content of translation for the given locale.
+     *
+     * @param string $locale
+     * @return Translation
+     */
+    public function getTranslation($locale)
+    {
+        foreach ($this->getTranslations() as $translation) {
+
+            if ($translation->getLocale() == $locale) {
+
+                return $translation;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Propel/TransUnitPeer.php
+++ b/Propel/TransUnitPeer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTransUnitPeer;
+
+class TransUnitPeer extends BaseTransUnitPeer
+{
+}

--- a/Propel/TransUnitQuery.php
+++ b/Propel/TransUnitQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTransUnitQuery;
+
+class TransUnitQuery extends BaseTransUnitQuery
+{
+}

--- a/Propel/TransUnitRepository.php
+++ b/Propel/TransUnitRepository.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+/**
+ * Repository for TransUnit entity.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class TransUnitRepository
+{
+    /**
+     * @var \PDO
+     */
+    protected $connection;
+
+    public function __construct(\PDO $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return PDO
+     */
+    protected function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Returns all domain available in database.
+     *
+     * @return array
+     */
+    public function getAllDomainsByLocale()
+    {
+        return TransUnitQuery::create()
+            ->joinWith('Translation')
+            ->withColumn('Translation.Locale', 'locale')
+            ->withColumn('Domain', 'domain')
+            ->select(array('locale', 'domain'))
+            ->groupBy('locale')
+            ->groupBy('domain')
+            ->find($this->getConnection())
+            ->getArrayCopy()
+        ;
+    }
+
+    /**
+     * Returns all domains for each locale.
+     *
+     * @return array
+     */
+    public function getAllByLocaleAndDomain($locale, $domain)
+    {
+        $unitsData = TransUnitQuery::create()
+            ->filterByDomain($domain)
+            ->joinWith('Translation')
+            ->useTranslationQuery()
+                ->filterByLocale($locale)
+            ->endUse()
+            ->setFormatter('PropelArrayFormatter')
+            ->find($this->getConnection())
+        ;
+
+        return $this->filterTransUnitData($unitsData);
+    }
+
+    /**
+     * Returns all trans unit with translations for the given domain and locale.
+     *
+     * @param string $locale
+     * @param string $domain
+     * @return array
+     */
+    public function getAllDomains()
+    {
+        $domains = TransUnitQuery::create()
+            ->select('Domain')
+            ->setDistinct()
+            ->orderByDomain(\Criteria::ASC)
+            ->find($this->getConnection())
+        ;
+
+        return array_values($domains->getArrayCopy());
+    }
+
+    /**
+     * Returns some trans units with their translations.
+     *
+     * @param array $locales
+     * @param int   $rows
+     * @param int   $page
+     * @param array $filters
+     * @return array
+     */
+    public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null)
+    {
+        $sortColumn = isset($filters['sidx']) ? $filters['sidx'] : 'id';
+        $order = isset($filters['sord']) ? $filters['sord'] : 'ASC';
+
+        $sortColumn = ucfirst($sortColumn);
+
+        $query = TransUnitQuery::create()
+            ->select('Id')
+        ;
+
+        $this->addTransUnitFilters($query, $locales, $filters);
+        $this->addTranslationFilter($query, $locales, $filters);
+
+        $ids = $query
+            ->orderBy($sortColumn, $order)
+            ->offset($rows * ($page-1))
+            ->limit($rows)
+            ->find($this->getConnection())
+        ;
+
+        $transUnits = array();
+
+        if (count($ids) > 0) {
+            $unitsData = TransUnitQuery::create()
+                ->filterById($ids, \Criteria::IN)
+                ->joinWith('Translation')
+                ->useTranslationQuery()
+                    ->filterByLocale($locales, \Criteria::IN)
+                ->endUse()
+                ->orderBy($sortColumn, $order)
+                ->setFormatter('PropelArrayFormatter')
+                ->find($this->getConnection())
+            ;
+
+            $transUnits = $this->filterTransUnitData($unitsData);
+        }
+
+        return $transUnits;
+    }
+
+    /**
+     * Count the number of trans unit.
+     *
+     * @param array $locales
+     * @param array $filters
+     * @return int
+     */
+    public function count(array $locales = null,  array $filters = null)
+    {
+        $query = TransUnitQuery::create()
+            ->select('Id')
+            ->distinct()
+        ;
+
+        $this->addTransUnitFilters($query, $locales, $filters);
+        $this->addTranslationFilter($query, $locales, $filters);
+
+        return $query->count($this->getConnection());
+    }
+
+    /**
+     * Returns all translations for the given file.
+     *
+     * @param File      $file
+     * @param boolean   $onlyUpdated
+     *
+     * @return array
+     */
+    public function getTranslationsForFile($file, $onlyUpdated)
+    {
+        $query = TranslationQuery::create()
+            ->filterByFile($file)
+            ->joinWith('TransUnit')
+        ;
+
+        if ($onlyUpdated) {
+            $query->add(null, TranslationPeer::UPDATED_AT.'>'.TranslationPeer::CREATED_AT, \Criteria::CUSTOM);
+        }
+
+        $results = $query
+            ->select(array('Content', 'TransUnit.Key'))
+            ->orderBy(TranslationPeer::ID, \Criteria::ASC)
+            ->find()
+        ;
+
+        $translations = array();
+        foreach ($results as $result) {
+            $translations[$result['TransUnit.Key']] = $result['Content'];
+        }
+
+        return $translations;
+    }
+
+    /**
+     * Add conditions according to given filters.
+     *
+     * @param TransUnitQuery    $query
+     * @param array             $locales
+     * @param array             $filters
+     */
+    protected function addTransUnitFilters(TransUnitQuery $query, array $locales = null, array $filters = null)
+    {
+        if (isset($filters['_search']) && $filters['_search']) {
+            if (!empty($filters['_domain'])) {
+                $query->filterByDomain(sprintf('%%%s%%', $filters['_domain']), \Criteria::LIKE);
+            }
+
+            if (!empty($filters['_key'])) {
+                $query->filterByKey(sprintf('%%%s%%', $filters['_key']), \Criteria::LIKE);
+            }
+        }
+    }
+
+    /**
+     * Add conditions according to given filters.
+     *
+     * @param TransUnitQuery    $query
+     * @param array             $locales
+     * @param array             $filters
+     */
+    protected function addTranslationFilter(TransUnitQuery $query, array $locales = null, array $filters = null)
+    {
+        if (null != $locales) {
+            $q = TransUnitQuery::create()
+                ->select('Id')
+                ->distinct()
+                ->join('Translation', \Criteria::LEFT_JOIN)
+                ->useTranslationQuery()
+                    ->filterByLocale($locales, \Criteria::IN)
+            ;
+
+            foreach ($locales as $locale) {
+                if (!empty($filters[$locale])) {
+                    $q
+                        ->filterByContent(sprintf('%%%s%%', $filters[$locale]), \Criteria::LIKE)
+                        ->filterByLocale(sprintf('%s', $locale))
+                    ;
+                }
+            }
+
+            $ids = $q
+                ->endUse()
+                ->find($this->getConnection())
+            ;
+
+            if (count($ids) > 0) {
+                $query->filterById($ids, \Criteria::IN);
+            }
+        }
+    }
+
+    /**
+     * Convert transUnit data with nested translations into the required format.
+     *
+     * @param array|PropelArrayCollection $transUnitData
+     * @return array
+     */
+    protected function filterTransUnitData($unitsData)
+    {
+        $cleaned = array();
+
+        foreach ($unitsData as $unit) {
+            /* @var $unit TransUnit */
+            $transUnit = array(
+                'id' => $unit['Id'],
+                'key' => $unit['Key'],
+                'domain' => $unit['Domain'],
+                'translations' => array(),
+            );
+
+            foreach ($unit['Translations'] as $translation)
+            {
+                $transUnit['translations'][] = array(
+                    'locale' => $translation['Locale'],
+                    'content' => $translation['Content'],
+                );
+            }
+
+            $cleaned[] = $transUnit;
+        }
+
+        return $cleaned;
+    }
+}

--- a/Propel/Translation.php
+++ b/Propel/Translation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTranslation;
+use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
+
+class Translation extends BaseTranslation implements TranslationInterface
+{
+
+}

--- a/Propel/TranslationPeer.php
+++ b/Propel/TranslationPeer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTranslationPeer;
+
+class TranslationPeer extends BaseTranslationPeer
+{
+}

--- a/Propel/TranslationQuery.php
+++ b/Propel/TranslationQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+use Lexik\Bundle\TranslationBundle\Propel\om\BaseTranslationQuery;
+
+class TranslationQuery extends BaseTranslationQuery
+{
+}

--- a/Resources/config/propel/schema.xml
+++ b/Resources/config/propel/schema.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<database name="default" defaultIdMethod="native" package="src"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://xsd.propelorm.org/1.6/database.xsd">
+    
+    <table name="lexik_translation_file" phpName="File" namespace="Lexik\Bundle\TranslationBundle\Propel">
+        <behavior name="auto_add_pk" />
+        
+        <column name="domain" type="varchar" size="255" default="messages" required="true" />
+        <column name="locale" type="varchar" size="10" required="true" />
+        <column name="extention" type="varchar" size="10" />
+        <column name="path" type="varchar" size="255" />
+        <column name="hash" type="varchar" size="255" />
+    </table>
+
+    <table name="lexik_trans_unit" phpName="TransUnit" namespace="Lexik\Bundle\TranslationBundle\Propel">
+        <behavior name="auto_add_pk" />
+        <behavior name="timestampable" />        
+        
+        <column name="domain" type="varchar" size="255" required="true" default="messages" />
+        <column name="key_name" phpName="Key" type="varchar" size="255" required="true" />
+        
+        <unique>
+            <unique-column name="key_name" />
+            <unique-column name="domain" />            
+        </unique>
+    </table>
+    
+    <table name="lexik_trans_unit_translations" phpName="Translation" namespace="Lexik\Bundle\TranslationBundle\Propel">
+        <behavior name="auto_add_pk" />
+        <behavior name="timestampable" />        
+        
+        <column name="file_id" type="integer" />
+        <column name="trans_unit_id" type="integer" required="true" />
+        <column name="locale" type="varchar" size="10" required="true" />
+        <column name="content" type="longvarchar" />
+        
+        <unique>
+            <unique-column name="trans_unit_id" />
+            <unique-column name="locale" />            
+        </unique>
+        
+        <foreign-key foreignTable="lexik_translation_file" onDelete="cascade">
+            <reference local="file_id" foreign="id" />
+        </foreign-key>
+        <foreign-key foreignTable="lexik_trans_unit" onDelete="cascade">
+            <reference local="trans_unit_id" foreign="id" />
+        </foreign-key>
+    </table>
+</database>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,6 +25,11 @@
         <parameter key="lexik_translation.mongodb.translation.class">Lexik\Bundle\TranslationBundle\Document\Translation</parameter>
         <parameter key="lexik_translation.mongodb.file.class">Lexik\Bundle\TranslationBundle\Document\File</parameter>
 
+        <parameter key="lexik_translation.propel.translation_storage.class">Lexik\Bundle\TranslationBundle\Storage\PropelStorage</parameter>
+        <parameter key="lexik_translation.propel.trans_unit.class">Lexik\Bundle\TranslationBundle\Propel\TransUnit</parameter>
+        <parameter key="lexik_translation.propel.translation.class">Lexik\Bundle\TranslationBundle\Propel\Translation</parameter>
+        <parameter key="lexik_translation.propel.file.class">Lexik\Bundle\TranslationBundle\Propel\File</parameter>
+
         <parameter key="lexik_translation.data_grid.formatter.class">Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridFormatter</parameter>
         <parameter key="lexik_translation.data_grid.request_handler.class">Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridRequestHandler</parameter>
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -52,8 +52,9 @@ lexik_translation:
     use_yml_tree:    false                                 # if "true" we will print a nice tree in the yml source files. It is a little slower.
     grid_input_type: text                                  # define field type used in the grid (text|textarea)
     storage:
-        type: orm                                          # where to store translations: "orm" or "mongodb"
+        type: orm                                          # where to store translations: "orm", "mongodb" or "propel"
         object_manager: something                          # The name of the entity / document manager which uses different connection (see: http://symfony.com/doc/current/cookbook/doctrine/multiple_entity_managers.html)
+                                                           # When using propel, this can be used to specify the propel connection name
     resources_registration:
         type:                 all                                  # resources type to register: "all", "files" or "database"
         managed_locales_only: true                                 # will only load resources for managed locales

--- a/Storage/DoctrineMongoDBStorage.php
+++ b/Storage/DoctrineMongoDBStorage.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\TranslationBundle\Storage;
 
-use Lexik\Bundle\TranslationBundle\Model\File;
 use Lexik\Bundle\TranslationBundle\Document\TransUnitRepository;
 use Lexik\Bundle\TranslationBundle\Document\FileRepository;
 
@@ -155,7 +154,7 @@ class DoctrineMongoDBStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getTranslationsFromFile(File $file, $onlyUpdated)
+    public function getTranslationsFromFile($file, $onlyUpdated)
     {
         return $this->getTransUnitRepository()->getTranslationsForFile($file, $onlyUpdated);
     }

--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\TranslationBundle\Storage;
 
-use Lexik\Bundle\TranslationBundle\Model\File;
 use Lexik\Bundle\TranslationBundle\Entity\FileRepository;
 use Lexik\Bundle\TranslationBundle\Entity\TransUnitRepository;
 
@@ -155,7 +154,7 @@ class DoctrineORMStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getTranslationsFromFile(File $file, $onlyUpdated)
+    public function getTranslationsFromFile($file, $onlyUpdated)
     {
         return $this->getTransUnitRepository()->getTranslationsForFile($file, $onlyUpdated);
     }

--- a/Storage/PropelStorage.php
+++ b/Storage/PropelStorage.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Storage;
+
+use Lexik\Bundle\TranslationBundle\Propel\FilePeer;
+use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
+use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnitPeer;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnitQuery;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnitRepository;
+
+/**
+ * Doctrine ORM storage class.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class PropelStorage implements StorageInterface
+{
+    /**
+     * @var string
+     */
+    private $connectionName;
+
+    /**
+     * @var PDO
+     */
+    private $connection;
+
+    /**
+     * @var array
+     */
+    private $classes;
+
+    /**
+     * @var array
+     */
+    private $collections = array();
+
+    /**
+     * @var TransUnitRepository
+     */
+    private $transUnitRepository;
+
+    /**
+     * @var FileRepository
+     */
+    private $fileRepository;
+
+    /**
+     * Constructor.
+     *
+     * @param string        $connection
+     * @param array         $classes
+     */
+    public function __construct($connectionName, array $classes)
+    {
+        $this->connectionName = $connectionName;
+        $this->classes = $classes;
+
+        $this->initCollections();
+    }
+
+    private function initCollections()
+    {
+        $this->collections = array();
+
+        foreach ($this->classes as $className) {
+            $this->initCollection($className);
+        }
+    }
+
+    private function initCollection($className)
+    {
+        $this->collections[$className] = new \PropelObjectCollection();
+        $this->collections[$className]->setModel($className);
+    }
+
+    /**
+     * @return PDO
+     */
+    private function getConnection()
+    {
+        if (null === $this->connection) {
+            $this->connection = \Propel::getConnection($this->connectionName);
+        }
+
+        return $this->connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist($entity)
+    {
+        $found = false;
+
+        foreach ($this->classes as $className) {
+            if ($entity instanceof $className) {
+                $this->collections[$className]->append($entity);
+                $found = true;
+
+                break;
+            }
+        }
+
+        if (!$found) {
+            throw new \RuntimeException(sprintf('Invalid entity class: "%s".', get_class($entity)));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush($entity = null)
+    {
+        if (null === $entity) {
+            foreach ($this->classes as $className) {
+                $this->collections[$className]->save();
+            }
+        } else {
+            $entity->save();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($entityName = null)
+    {
+         if (null === $entityName) {
+             $this->initCollections();
+         } else {
+             $this->initCollection($entityName);
+         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getModelClass($name)
+    {
+        if ( !isset($this->classes[$name]) ) {
+            throw new \RuntimeException(sprintf('No class defined for name "%s".', $name));
+        }
+
+        return $this->classes[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilesByLocalesAndDomains(array $locales, array $domains)
+    {
+        return $this->getFileRepository()->findForLocalesAndDomains($locales, $domains);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileByHash($hash)
+    {
+        return FileQuery::create()->findOneByHash($hash, $this->getConnection());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitDomains()
+    {
+        return $this->getTransUnitRepository()->getAllDomains();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitById($id)
+    {
+        return TransUnitQuery::create()->findOneById($id, $this->getConnection());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitByKeyAndDomain($key, $domain)
+    {
+        $key = mb_substr($key, 0, 255, 'UTF-8');
+
+        $fields = array(
+            'Key' => $key,
+            'Domain'   => $domain,
+        );
+
+        return TransUnitQuery::create()->findOneByArray($fields, $this->getConnection());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitDomainsByLocale()
+    {
+        return $this->getTransUnitRepository()->getAllDomainsByLocale();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitsByLocaleAndDomain($locale, $domain)
+    {
+        return $this->getTransUnitRepository()->getAllByLocaleAndDomain($locale, $domain);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null)
+    {
+        return $this->getTransUnitRepository()->getTransUnitList($locales, $rows, $page, $filters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function countTransUnits(array $locales = null, array $filters = null)
+    {
+        return $this->getTransUnitRepository()->count($locales, $filters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationsFromFile($file, $onlyUpdated)
+    {
+        return $this->getTransUnitRepository()->getTranslationsForFile($file, $onlyUpdated);
+    }
+
+    /**
+     * Returns true if translation tables exist.
+     *
+     * @return boolean
+     */
+    public function translationsTablesExist()
+    {
+        return true;
+    }
+
+    /**
+     * Returns the TransUnit repository.
+     *
+     * @return TransUnitRepository
+     */
+    protected function getTransUnitRepository()
+    {
+        if (null === $this->transUnitRepository) {
+            $this->transUnitRepository = new TransUnitRepository($this->getConnection());
+        }
+
+        return $this->transUnitRepository;
+    }
+
+    /**
+     * Returns the File repository.
+     *
+     * @return FileRepository
+     */
+    protected function getFileRepository()
+    {
+        if (null === $this->fileRepository) {
+            $this->fileRepository = new FileRepository($this->getConnection());
+        }
+
+        return $this->fileRepository;
+    }
+}

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -2,8 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Storage;
 
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
-use Lexik\Bundle\TranslationBundle\Model\File;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 
 /**
  * Translation stoage interface.
@@ -83,7 +82,7 @@ interface StorageInterface
      *
      * @param string $key
      * @param string $domain
-     * @return TransUnit
+     * @return TransUnitInterface
      */
     public function getTransUnitByKeyAndDomain($key, $domain);
 
@@ -119,9 +118,9 @@ interface StorageInterface
     /**
      * Returns all translations for the given file.
      *
-     * @param File    $file
-     * @param boolean $onlyUpdated
+     * @param FileInterface $file
+     * @param boolean       $onlyUpdated
      * @return array
      */
-    public function getTranslationsFromFile(File $file, $onlyUpdated);
+    public function getTranslationsFromFile($file, $onlyUpdated);
 }

--- a/Tests/Fixtures/TransUnitDataPropel.php
+++ b/Tests/Fixtures/TransUnitDataPropel.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Tests\Fixtures;
+
+use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
+use Lexik\Bundle\TranslationBundle\Propel\TranslationQuery;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnitQuery;
+use Lexik\Bundle\TranslationBundle\Propel\File;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnit;
+use Lexik\Bundle\TranslationBundle\Propel\Translation;
+
+/**
+ * Tests fixtures class for Propel.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class TransUnitDataPropel
+{
+    /**
+     * (non-PHPdoc)
+     * @see Doctrine\Common\DataFixtures.FixtureInterface::load()
+     */
+    public function load(\PropelPDO $con)
+    {
+        // add files
+        $files = array();
+        $domains = array(
+            'superTranslations' => array('fr', 'en', 'de'),
+            'messages' => array('fr', 'en'),
+        );
+
+        foreach ($domains as $name => $locales) {
+            foreach ($locales as $locale) {
+                $file = new File();
+                $file->setDomain($name);
+                $file->setLocale($locale);
+                $file->setExtention('yml');
+                $file->setPath('Resources/translations');
+                $file->setHash(md5(sprintf('Resources/translations/%s.%s.yml', $name, $locale)));
+
+                $file->save($con);
+                $files[$name][$locale] = $file;
+            }
+        }
+
+        // add translations for "key.say_hello"
+        $transUnit = new TransUnit();
+        $transUnit->setKey('key.say_hello');
+        $transUnit->setDomain('superTranslations');
+
+        $translations = array(
+           'fr' => 'salut',
+           'en' => 'hello',
+           'de' => 'heil',
+        );
+
+        foreach ($translations as $locale => $content) {
+            $translation = new Translation();
+            $translation->setLocale($locale);
+            $translation->setContent($content);
+            $translation->setFile($files['superTranslations'][$locale]);
+            $translation->setTransUnit($transUnit);
+            $translation->save($con);
+        }
+
+        $transUnit->save($con);
+
+        // add translations for "key.say_goodbye"
+        $transUnit = new TransUnit();
+        $transUnit->setKey('key.say_goodbye');
+
+        $translations = array(
+            'fr' => 'au revoir',
+            'en' => 'goodbye',
+        );
+
+        foreach ($translations as $locale => $content) {
+            $translation = new Translation();
+            $translation->setLocale($locale);
+            $translation->setContent($content);
+            $translation->setFile($files['messages'][$locale]);
+            $translation->setTransUnit($transUnit);
+            $translation->save($con);
+        }
+
+        $transUnit->save($con);
+
+        // add translations for "key.say_wtf"
+        $transUnit = new TransUnit();
+        $transUnit->setKey('key.say_wtf');
+
+        $translations = array(
+            'fr' => 'c\'est quoi ce bordel !?!',
+            'en' => 'what the fuck !?!',
+        );
+
+        foreach ($translations as $locale => $content) {
+            $translation = new Translation();
+            $translation->setLocale($locale);
+            $translation->setContent($content);
+            $translation->setFile($files['messages'][$locale]);
+            $translation->setTransUnit($transUnit);
+            $translation->save($con);
+        }
+
+        $transUnit->save($con);
+    }
+}

--- a/Tests/Unit/BaseUnitTestCase.php
+++ b/Tests/Unit/BaseUnitTestCase.php
@@ -13,6 +13,8 @@ use Doctrine\ORM\Tools\Setup;
 use Lexik\Bundle\TranslationBundle\Storage\DoctrineMongoDBStorage;
 use Lexik\Bundle\TranslationBundle\Storage\DoctrineORMStorage;
 use Lexik\Bundle\TranslationBundle\Tests\Fixtures\TransUnitData;
+use Lexik\Bundle\TranslationBundle\Tests\Fixtures\TransUnitDataPropel;
+use Lexik\Bundle\TranslationBundle\Storage\PropelStorage;
 
 /**
  * Base unit test class providing functions to create a mock entity manger, load schema and fixtures.
@@ -28,6 +30,10 @@ abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
     const DOCUMENT_TRANS_UNIT_CLASS  = 'Lexik\Bundle\TranslationBundle\Document\TransUnit';
     const DOCUMENT_TRANSLATION_CLASS = 'Lexik\Bundle\TranslationBundle\Document\Translation';
     const DOCUMENT_FILE_CLASS        = 'Lexik\Bundle\TranslationBundle\Document\File';
+
+    const PROPEL_TRANS_UNIT_CLASS  = 'Lexik\Bundle\TranslationBundle\Propel\TransUnit';
+    const PROPEL_TRANSLATION_CLASS = 'Lexik\Bundle\TranslationBundle\Propel\Translation';
+    const PROPEL_FILE_CLASS        = 'Lexik\Bundle\TranslationBundle\Propel\File';
 
     /**
      * Create astorage class form doctrine ORM.
@@ -58,6 +64,22 @@ abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
             'trans_unit'  => self::DOCUMENT_TRANS_UNIT_CLASS,
             'translation' => self::DOCUMENT_TRANSLATION_CLASS,
             'file'        => self::DOCUMENT_FILE_CLASS,
+        ));
+
+        return $storage;
+    }
+
+    /**
+     * Create a storage class for Propel.
+     *
+     * @return \Lexik\Bundle\TranslationBundle\Storage\PropelStorage
+     */
+    protected function getPropelStorage()
+    {
+        $storage = new PropelStorage(null, array(
+            'trans_unit'  => self::PROPEL_TRANS_UNIT_CLASS,
+            'translation' => self::PROPEL_TRANSLATION_CLASS,
+            'file'        => self::PROPEL_FILE_CLASS,
         ));
 
         return $storage;
@@ -96,6 +118,15 @@ abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
 
         $fixtures = new TransUnitData();
         $executor->execute(array($fixtures), false);
+    }
+
+    /**
+     * Load test fixtures for Propel.
+     */
+    protected function loadPropelFixtures(\PropelPDO $con)
+    {
+        $fixtures = new TransUnitDataPropel();
+        $fixtures->load($con);
     }
 
     /**
@@ -175,5 +206,18 @@ abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
         $dm = \Doctrine\ODM\MongoDB\DocumentManager::create($conn, $config);
 
         return $dm;
+    }
+
+    /**
+     * @return \PropelPDO
+     */
+    protected function getMockPropelConnection()
+    {
+        $builder = new \PropelQuickBuilder();
+        $builder->setSchema(file_get_contents(__DIR__.'/../../Resources/config/propel/schema.xml'));
+        $builder->setClassTargets(array('tablemap', 'peer', 'object', 'query'));
+        $con = $builder->build();
+
+        return $con;
     }
 }

--- a/Tests/Unit/Repository/Propel/FileRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/FileRepositoryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Repository\Propel;
+
+use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
+use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
+
+/**
+ * Unit test for File entity's repository class.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class FileRepositoryTest extends BaseUnitTestCase
+{
+    /**
+     * @group orm
+     */
+    public function testFindForLocalesAndDomains()
+    {
+        $con = $this->getMockPropelConnection();
+        $this->loadPropelFixtures($con);
+
+        $repository = new FileRepository($con);
+
+        $result = $repository->findForLocalesAndDomains(array('de'), array());
+        $expected = array(
+            'Resources/translations/superTranslations.de.yml',
+        );
+        $this->assertEquals(1, count($result));
+        $this->assertFilesPath($expected, $result);
+
+        $result = $repository->findForLocalesAndDomains(array('fr'), array());
+        $expected = array(
+            'Resources/translations/superTranslations.fr.yml',
+            'Resources/translations/messages.fr.yml',
+        );
+        $this->assertEquals(2, count($result));
+        $this->assertFilesPath($expected, $result);
+
+        $result = $repository->findForLocalesAndDomains(array(), array('messages'));
+        $expected = array(
+            'Resources/translations/messages.fr.yml',
+            'Resources/translations/messages.en.yml',
+        );
+        $this->assertEquals(2, count($result));
+
+        $result = $repository->findForLocalesAndDomains(array('en', 'de'), array('messages', 'superTranslations'));
+        $expected = array(
+            'Resources/translations/superTranslations.en.yml',
+            'Resources/translations/superTranslations.de.yml',
+            'Resources/translations/messages.en.yml',
+        );
+        $this->assertEquals(3, count($result));
+        $this->assertFilesPath($expected, $result);
+    }
+
+    /**
+     * Check files path.
+     *
+     * @param array $expected
+     * @param array $result
+     */
+    public function assertFilesPath($expected, $result)
+    {
+        $i = 0;
+        foreach ($result as $file) {
+            $this->assertEquals($expected[$i], $file->getPath().'/'.$file->getName());
+            $i++;
+        }
+    }
+}

--- a/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Repository\Propel;
+
+use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
+use Lexik\Bundle\TranslationBundle\Propel\TransUnitRepository;
+use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
+use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
+use Lexik\Bundle\TranslationBundle\Propel\TranslationQuery;
+
+/**
+ * Unit test for TransUnit entity's repository class.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class TransUnitRepositoryTest extends BaseUnitTestCase
+{
+    /**
+     * @group orm
+     */
+    public function testGetAllDomainsByLocale()
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $results = $repository->getAllDomainsByLocale();
+        $expected = array(
+            array('locale' => 'de', 'domain' => 'superTranslations'),
+            array('locale' => 'en', 'domain' => 'messages'),
+            array('locale' => 'en', 'domain' => 'superTranslations'),
+            array('locale' => 'fr', 'domain' => 'messages'),
+            array('locale' => 'fr', 'domain' => 'superTranslations'),
+        );
+
+        $this->assertSame($expected, $results);
+    }
+
+    /**
+     * @group orm
+     */
+    public function testGetAllDomains()
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $results = $repository->getAllDomains();
+        $expected = array('messages', 'superTranslations');
+
+        $this->assertSame($expected, $results);
+    }
+
+    /**
+     * @group orm
+     */
+    public function testGetAllByLocaleAndDomain()
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $results = $repository->getAllByLocaleAndDomain('de', 'messages');
+        $expected = array();
+        $this->assertSameTransUnit($expected, $results);
+
+        $results = $repository->getAllByLocaleAndDomain('de', 'superTranslations');
+        $expected = array(
+            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(array('locale' => 'de', 'content' => 'heil'))),
+        );
+        $this->assertSameTransUnit($expected, $results);
+
+        $results = $repository->getAllByLocaleAndDomain('en', 'messages');
+        $expected = array(
+            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(array('locale' => 'en', 'content' => 'goodbye'))),
+            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(array('locale' => 'en', 'content' => 'what the fuck !?!'))),
+        );
+        $this->assertSameTransUnit($expected, $results);
+    }
+
+    /**
+     * @group orm
+     * @dataProvider countProvider
+     */
+    public function testCount($expectedCount, $arguments)
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $count = call_user_func_array(array($repository, 'count'), $arguments);
+
+        $this->assertEquals($expectedCount, $count);
+    }
+
+    public function countProvider()
+    {
+        return array(
+            array(3, array(array('fr', 'de', 'en'), array())),
+            array(3, array(array('fr', 'it'), array())),
+            array(3, array(array('fr', 'de'), array('_search' => false, '_key' => 'good'))),
+            array(1, array(array('fr', 'de'), array('_search' => true, '_key' => 'good'))),
+            array(1, array(array('en', 'de'), array('_search' => true, '_domain' => 'super'))),
+            array(1, array(array('en', 'fr', 'de'), array('_search' => true, '_key' => 'hel', '_domain' => 'uper'))),
+            array(2, array(array('en', 'de'), array('_search' => true, '_key' => 'say', '_domain' => 'ssa'))),
+        );
+    }
+
+    /**
+     * @group orm
+     */
+    public function testGetTransUnitList()
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'ASC'));
+        $expected = array(
+            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'fr', 'content' => 'au revoir'),
+            )),
+            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
+                array('locale' => 'de', 'content' => 'heil'),
+                array('locale' => 'fr', 'content' => 'salut'),
+            )),
+            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+
+        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, '_domain' => 'mess'));
+        $expected = array(
+            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
+            )),
+            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'fr', 'content' => 'au revoir'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+
+        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, '_domain' => 'mess', '_key' => 'oo'));
+        $expected = array(
+            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'fr', 'content' => 'au revoir'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+
+        $result = $repository->getTransUnitList(array('fr', 'en'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'fr' => 'alu'));
+        $expected = array(
+            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
+                array('locale' => 'en', 'content' => 'hello'),
+                array('locale' => 'fr', 'content' => 'salut'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+
+        $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 1, array('sidx' => 'domain', 'sord' => 'ASC'));
+        $expected = array(
+            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'en', 'content' => 'goodbye'),
+                array('locale' => 'fr', 'content' => 'au revoir'),
+            )),
+            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
+                array('locale' => 'en', 'content' => 'what the fuck !?!'),
+                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+
+        $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 2, array('sidx' => 'domain', 'sord' => 'ASC'));
+        $expected = array(
+            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
+                array('locale' => 'de', 'content' => 'heil'),
+                array('locale' => 'en', 'content' => 'hello'),
+                array('locale' => 'fr', 'content' => 'salut'),
+            )),
+        );
+        $this->assertSameTransUnit($expected, $result);
+    }
+
+    /**
+     * @group orm
+     */
+    public function testGetTranslationsForFile()
+    {
+        $con = $this->loadDatabase();
+        $repository = new TransUnitRepository($con);
+
+        $file = FileQuery::create()->findOneByArray(array(
+            'Domain' => 'messages',
+            'Locale' => 'fr',
+            'Extention' => 'yml',
+        ), $con);
+        $this->assertInstanceOf(self::PROPEL_FILE_CLASS, $file);
+
+        $result = $repository->getTranslationsForFile($file, false);
+        $expected = array(
+            'key.say_goodbye' => 'au revoir',
+            'key.say_wtf' => 'c\'est quoi ce bordel !?!',
+        );
+        $this->assertEquals($expected, $result);
+
+        // update a translation and then get translations with onlyUpdated = true
+        $now = new \DateTime('now');
+        $now->modify('+2 days');
+
+        TranslationQuery::create()
+            ->filterByLocale('fr')
+            ->filterByContent('au revoir')
+            ->update(array('UpdatedAt' => $now), $con, false)
+        ;
+
+        $result = $repository->getTranslationsForFile($file, true);
+        $expected = array(
+            'key.say_goodbye' => 'au revoir',
+        );
+        $this->assertEquals($expected, $result);
+    }
+
+    protected function assertSameTransUnit($expected, $result)
+    {
+        $this->assertEquals(count($expected), count($result));
+
+        foreach ($expected as $i => $transUnit) {
+            $this->assertEquals($transUnit['id'], $result[$i]['id']);
+            $this->assertEquals($transUnit['key'], $result[$i]['key']);
+            $this->assertEquals($transUnit['domain'], $result[$i]['domain']);
+
+            $this->assertEquals(count($transUnit['translations']), count($result[$i]['translations']));
+
+            foreach ($transUnit['translations'] as $j => $translation) {
+                $this->assertEquals($translation['locale'], $result[$i]['translations'][$j]['locale']);
+                $this->assertEquals($translation['content'], $result[$i]['translations'][$j]['content']);
+            }
+        }
+    }
+
+    protected function loadDatabase()
+    {
+        $con = $this->getMockPropelConnection();
+        $this->loadPropelFixtures($con);
+
+        return $con;
+    }
+}

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -4,10 +4,10 @@ namespace Lexik\Bundle\TranslationBundle\Translation\Importer;
 
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Document\TransUnit as TransUnitDocument;
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
-use Lexik\Bundle\TranslationBundle\Model\Translation;
 use Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitManagerInterface;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
+use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
 
 /**
  * Import a translation file into the database.
@@ -76,12 +76,12 @@ class FileImporter
                 }
                 $transUnit = $this->storage->getTransUnitByKeyAndDomain($key, $domain);
 
-                if (!($transUnit instanceof TransUnit)) {
+                if (!($transUnit instanceof TransUnitInterface)) {
                     $transUnit = $this->transUnitManager->create($key, $domain);
                 }
 
                 $translation = $this->transUnitManager->addTranslation($transUnit, $locale, $content, $translationFile);
-                if ($translation instanceof Translation) {
+                if ($translation instanceof TranslationInterface) {
                     $imported++;
                 } else if($forceUpdate) {
                     $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content);

--- a/Util/DataGrid/DataGridFormatter.php
+++ b/Util/DataGrid/DataGridFormatter.php
@@ -4,7 +4,7 @@ namespace Lexik\Bundle\TranslationBundle\Util\DataGrid;
 
 use Symfony\Component\HttpFoundation\JsonResponse;
 
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
@@ -116,10 +116,10 @@ class DataGridFormatter
     /**
      * Convert a trans unit into an array.
      *
-     * @param TransUnit $transUnit
+     * @param TransUnitInterface $transUnit
      * @return array
      */
-    protected function toArray(TransUnit $transUnit)
+    protected function toArray(TransUnitInterface $transUnit)
     {
         $data = array(
             'id'           => $transUnit->getId(),

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,13 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.3"
     },
+    "require-dev": {
+        "propel/propel-bundle": "~1.2"
+    },
     "suggest": {
         "doctrine/orm": ">=2.1",
-        "doctrine/mongodb-odm": "1.0.*@dev"
+        "doctrine/mongodb-odm": "1.0.*@dev",
+        "propel/propel-bundle": "~1.2"
     },
     "autoload":     {
         "psr-0": { "Lexik\\Bundle\\TranslationBundle": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         processIsolation="false"
+         processIsolation="true"
          stopOnFailure="false"
          syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"


### PR DESCRIPTION
This is a complete propel storage implementation including tests (at least the same tests that are already in place for the orm/mongodb storage).

To make things work, I had to make a few changes to the existing classes and interfaces (mainly replacing class references by new interfaces), so technically it might be a BC break for people who have overridden some of the services. For users just following the installation docs everything should be fine.

Besides the unit tests (everything green) I did some manual tests on the translation frontend and it seems to work great. I can't test the doctrine/mongodb version here - someone else should do this to make sure everything is ok.

I hope this gets merged - I've been looking for a good propel based translator for a while and patching this one was actually the easiest solution.
