### PR TITLE
Fix formatter for Mongo if called from format

### DIFF
--- a/Util/DataGrid/DataGridFormatter.php
+++ b/Util/DataGrid/DataGridFormatter.php
@@ -90,10 +90,12 @@ class DataGridFormatter
     {
         if (is_object($transUnit)) {
             $transUnit = $this->toArray($transUnit);
+        } elseif ('mongodb' == $this->storage) {
+            $transUnit['id'] = $transUnit['_id']->{'$id'};
         }
 
         $formatted = array(
-            '_id'     => ('mongodb' == $this->storage) ? $transUnit['_id']->{'$id'} : $transUnit['id'],
+            '_id'     => $transUnit['id'],
             '_domain' => $transUnit['domain'],
             '_key'    => $transUnit['key'],
         );


### PR DESCRIPTION
If formatOne is called from format, the transUnit is already an array that contains the [_id]. 
If formatOne is called from createSingleResponse, it uses toArray which sets the ['id'] field. In this case it  no longer has ["_id'], so it fails. 

This commit fixes this by setting the ['id'] field if the transUnit is not an object and mongo is the storage engine. This way there always is an ['id'] field.
