### PR TITLE
Fixed invalid resources path leading to Exception

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -91,7 +91,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         $classes = array(
             'Symfony\Component\Validator\Validator' => '/Resources/translations',
             'Symfony\Component\Form\Form' => '/Resources/translations',
-            'Symfony\Component\Security\Core\Exception\AuthenticationException' => '/../Resources/translations',
+            'Symfony\Component\Security\Core\Exception\AuthenticationException' => '/../../Resources/translations',
         );
 
         $dirs = array();


### PR DESCRIPTION
The current path given in the code is wrong for Symfony 2.3 until 2.5 and leads to an exception while importing translations. In 2.6-dev the path has been copied, so both versions should be alright.
