### PR TITLE
Updated composer.json and .travis.yml to make 2.5.* tests work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 env:
   - SYMFONY_VERSION=2.3.*
   - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=2.5.*
+  - SYMFONY_VERSION="~2.5.5"
 
 before_script:
   - phpenv config-add travis-php.ini
@@ -25,10 +25,6 @@ before_script:
   - composer require symfony/validator:${SYMFONY_VERSION} --no-update
   - composer require symfony/finder:${SYMFONY_VERSION} --no-update
   - composer require symfony/doctrine-bridge:${SYMFONY_VERSION} --no-update
-  - composer require doctrine/orm:2.4.* --no-update
-  - composer require doctrine/data-fixtures:1.0.* --no-update
-  - composer require doctrine/mongodb-odm:dev-master --no-update
-  - composer require doctrine/mongodb-odm-bundle:dev-master --no-update
   - composer update --dev
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["Symfony2", "bundle", "translation", "i18n"],
     "homepage": "https://github.com/lexik/LexikTranslationBundle",
     "license": "MIT",
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "authors": [
         {
@@ -22,10 +22,14 @@
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
+        "doctrine/orm": "2.4.*",
+        "doctrine/data-fixtures": "1.0.*",
+        "doctrine/mongodb-odm": "dev-master",
+        "doctrine/mongodb-odm-bundle": "dev-master",
         "propel/propel-bundle": "~1.2"
     },
     "suggest": {
-        "doctrine/orm": ">=2.1",
+        "doctrine/orm": ">=2.4",
         "doctrine/mongodb-odm": "1.0.*@dev",
         "propel/propel-bundle": "~1.2"
     },


### PR DESCRIPTION
The Symfony 2.5.\* tests used to fail because the composer installation timed out. This has been fixed now, basically by requiring Symfony >= 2.5.5 (somthing must have been messed up with earlier versions' dependencies). I also moved all those doctrine packages to the require-dev section instead of always including them separately.

Can you also please add the 2.1.0 stable version? This would be very helpful for component inclusion in other projects.
