### PR TITLE
Documented the necessity of installing assets

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -29,6 +29,10 @@ $bundles = array(
 );
 ```
 
+Then install the required assets:
+
+    ./app/console assets:install
+
 ___________________
 
 Configuration


### PR DESCRIPTION
I was installing this bundle, and I got JS errors. Appeared I had to install the assets, which wasn't documented. Added it.
