### PR TITLE
Fix sorting error

### DIFF
--- a/Resources/public/js/translation.js
+++ b/Resources/public/js/translation.js
@@ -55,7 +55,7 @@ app.controller('TranslationCtrl', [
 
                 if (Object.keys(params.sorting()).length) {
                     var keys = Object.keys(params.sorting());
-                    parameters['sidx'] = keys[0];
+                    parameters['sidx'] = keys[0].replace('_', '');
                     parameters['sord'] = params.sorting()[keys[0]];
 
                     if (!angular.equals(this.currentSort, params.sorting())) {


### PR DESCRIPTION
We need to remove the _ before id, domain or key to avoid this kind of errors:

CRITICAL: Uncaught PHP Exception Doctrine\ORM\Query\QueryException: "[Semantical Error] line 0, col 5355 near '_domain asc': Error: Class Lexik\Bundle\TranslationBundle\Entity\TransUnit has no field or association named _domain" at /srv/ic2m/novento/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php line 63 {"exception":"[object] (Doctrine\ORM\Query\QueryException: [Semantical Error] line 0, col 5355 near '_domain asc': Error: Class Lexik\Bundle\TranslationBundle\Entity\TransUnit has no field or association named _domain at /srv/ic2m/novento/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:63, Doctrine\ORM\Query\QueryException: SELECT tu.id FROM Lexik\Bundle\TranslationBundle\Entity\TransUnit tu WHERE tu.id
