### PR TITLE
Fixed bad path to the app directory at TransUnitFormHandler definition.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -122,7 +122,7 @@
             <argument type="service" id="lexik_translation.file.manager" />
             <argument type="service" id="lexik_translation.translation_storage" />
             <argument>%lexik_translation.managed_locales%</argument>
-            <argument>%kernel.cache_dir%</argument>
+            <argument>%kernel.root_dir%</argument>
         </service>
 
         <!-- Listener -->


### PR DESCRIPTION
Add new translations dosen't work at my project.

While create new TransUnit, its translations are linked to the real files at <code> line 96 TransUnitFormHandler</code>

But <code>$this->rootDir.'/Resources/translations'</code> points to something like <code>../app/cache/[env]/Resources/translations</code> which doesn't exists. 
Even that, a new entity file is created with non existent path property:<code>/cache/[env]/Resources/translations</code>
The translation is created succesfully. But while export will there be an error: 
<code>
Output file: /app/cache/dev/Resources/translations/messages.pl.yml
1 translations to export: PHP Warning:  file_put_contents(app/cache/dev/Resources/translations/messages.pl.yml): failed to open stream: No such file or directory in vendor/lexik/translation-bundle/Lexik/Bundle/TranslationBundle/Translation/Exporter/YamlExporter.php on line 39</code>

That is why I changed 5th argument definition of TransUnitFormHandler from <code>%kernel.cache_dir%</code>  to <code>%kernel.root_dir%</code> at services.xml, which points to real file path: app/Resources/translations/messages.[locale].yml

My local info:
PHP 5.4.30
Symfony 2.3.19