### PR TITLE
added option to run import as case insensitive and ...

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,8 @@
         <parameter key="lexik_translation.form.handler.trans_unit.class">Lexik\Bundle\TranslationBundle\Form\Handler\TransUnitFormHandler</parameter>
 
         <parameter key="lexik_translation.listener.get_database_resources.class">Lexik\Bundle\TranslationBundle\Translation\GetDatabaseResourcesListener</parameter>
+
+        <parameter key="lexik_translation.importer.case_insensitive">false</parameter>
     </parameters>
 
     <services>
@@ -78,6 +80,9 @@
             <argument type="service" id="lexik_translation.translation_storage" />
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.file.manager" />
+            <call method="setCaseInsensitiveInsert">
+                <argument>%lexik_translation.importer.case_insensitive%</argument>
+            </call>
         </service>
 
         <!-- Exporter -->

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -106,13 +106,14 @@ Command options:
 * `--globals` (or `-g`): import only from the `app/Resources/translations`. It will ignore the option if you provide a BundleName to import.
 * `--locales` (or `-l`): import only for these locales, instead of using the managed locales from the config. eg: `--locales=fr --locales=en`
 * `--domains` (or `-d`): Only export files for given domains (comma separated). eg `--domains=messages,validators`
+* `--case-insensitive` (or `-i`): Convert keys as lower case to check if a key has already been imported.
 
 Export translations
 ===================
 
 To export translations from the database in to files run the following command:
 
-    ./app/console lexik:translations:export [--locales=en,de] [--domains=messages,validators] [--format=yml]
+    ./app/console lexik:translations:export [--locales=en,de] [--domains=messages,validators] [--format=yml] [--case-insensitive]
 
 This command will export all translations from the database in to files. A translation is exported in the same file (and format) it was imported in,
 except for vendors files which are exported in `app/Resources/translations/` and in this case the command will only export translations that changed.


### PR DESCRIPTION
... avoid duplicate key error

Usage:
`app/console lexik:translations:import --case-insensitive`

Also replace PR https://github.com/lexik/LexikTranslationBundle/pull/121