### PR TITLE
Added CleanTranslationCacheListener

### DIFF
--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -19,10 +19,11 @@ class TranslationController extends Controller
     public function gridAction()
     {
         return $this->render('LexikTranslationBundle:Translation:grid.html.twig', array(
-            'layout'        => $this->container->getParameter('lexik_translation.base_layout'),
-            'inputType'     => $this->container->getParameter('lexik_translation.grid_input_type'),
-            'toggleSimilar' => $this->container->getParameter('lexik_translation.grid_toggle_similar'),
-            'locales'       => $this->getManagedLocales(),
+            'layout'         => $this->container->getParameter('lexik_translation.base_layout'),
+            'inputType'      => $this->container->getParameter('lexik_translation.grid_input_type'),
+            'autoCacheClean' => $this->container->getParameter('lexik_translation.auto_cache_clean'),
+            'toggleSimilar'  => $this->container->getParameter('lexik_translation.grid_toggle_similar'),
+            'locales'        => $this->getManagedLocales(),
         ));
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,6 +64,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                 ->end()
 
+                ->booleanNode('auto_cache_clean')
+                    ->defaultValue(false)
+                ->end()
+
                 ->arrayNode('storage')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/Document/TransUnitRepository.php
+++ b/Document/TransUnitRepository.php
@@ -292,4 +292,24 @@ FCT;
             }
         }
     }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getLatestTranslationUpdatedAt()
+    {
+        $result = $this->createQueryBuilder()
+            ->hydrate(false)
+            ->select('translations.updatedAt')
+            ->sort('translations.updatedAt', 'desc')
+            ->limit(1)
+            ->getQuery()
+            ->getSingleResult();
+
+        if (!isset($result['translations'], $result['translations'][0])) {
+            return null;
+        }
+
+        return new \DateTime(date('Y-m-d H:i:s', $result['translations'][0]['updated_at']->sec));
+    }
 }

--- a/Entity/TranslationRepository.php
+++ b/Entity/TranslationRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Entity;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Repository for Translation entity.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class TranslationRepository extends EntityRepository
+{
+    /**
+     * @return \DateTime|null
+     */
+    public function getLatestTranslationUpdatedAt()
+    {
+        $date = $this->createQueryBuilder('t')
+            ->select('MAX(t.updatedAt)')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return !empty($date) ? new \DateTime($date) : null;
+    }
+}

--- a/EventDispatcher/CleanTranslationCacheListener.php
+++ b/EventDispatcher/CleanTranslationCacheListener.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\EventDispatcher;
+
+use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class CleanTranslationCacheListener
+{
+    /**
+     * @var StorageInterface
+     */
+    private $storage;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var string
+     */
+    private $cacheDirectory;
+
+    /**
+     * @var array
+     */
+    private $managedLocales;
+
+    /**
+     * Constructor
+     *
+     * @param StorageInterface    $storage
+     * @param TranslatorInterface $translator
+     * @param string              $cacheDirectory
+     * @param array               $managedLocales
+     */
+    public function __construct(StorageInterface $storage, TranslatorInterface $translator, $cacheDirectory, $managedLocales)
+    {
+        $this->storage = $storage;
+        $this->cacheDirectory = $cacheDirectory;
+        $this->translator = $translator;
+        $this->managedLocales = $managedLocales;
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if ($event->isMasterRequest()) {
+            throw new \RuntimeException('TODO Bwaaahhhaha');
+
+//            $qb = $this->em->createQueryBuilder();
+//            $qb->select('max(t.updatedAt)')
+//                ->from('LexikTranslationBundle:Translation', 't');
+//
+//            $lastUpdateTime = $qb->getQuery()->getSingleScalarResult();
+//
+//            $finder = new Finder();
+//            $finder->files()->in($this->cacheDirectory.'/translations')->date('< '.$lastUpdateTime);
+//
+//            if ($finder->count() > 0) {
+//                $this->translator->removeLocalesCacheFiles($this->managedLocales);
+//            }
+        }
+    }
+}

--- a/EventDispatcher/CleanTranslationCacheListener.php
+++ b/EventDispatcher/CleanTranslationCacheListener.php
@@ -54,20 +54,18 @@ class CleanTranslationCacheListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         if ($event->isMasterRequest()) {
-            throw new \RuntimeException('TODO Bwaaahhhaha');
+            $lastUpdateTime = $this->storage->getLatestUpdatedAt();
 
-//            $qb = $this->em->createQueryBuilder();
-//            $qb->select('max(t.updatedAt)')
-//                ->from('LexikTranslationBundle:Translation', 't');
-//
-//            $lastUpdateTime = $qb->getQuery()->getSingleScalarResult();
-//
-//            $finder = new Finder();
-//            $finder->files()->in($this->cacheDirectory.'/translations')->date('< '.$lastUpdateTime);
-//
-//            if ($finder->count() > 0) {
-//                $this->translator->removeLocalesCacheFiles($this->managedLocales);
-//            }
+            if ($lastUpdateTime instanceof \DateTime) {
+                $finder = new Finder();
+                $finder->files()
+                    ->in($this->cacheDirectory.'/translations')
+                    ->date('< '.$lastUpdateTime->format('Y-m-d H:i:s'));
+
+                if ($finder->count() > 0) {
+                    $this->translator->removeLocalesCacheFiles($this->managedLocales);
+                }
+            }
         }
     }
 }

--- a/EventDispatcher/Event/GetDatabaseResourcesEvent.php
+++ b/EventDispatcher/Event/GetDatabaseResourcesEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lexik\Bundle\TranslationBundle\Translation;
+namespace Lexik\Bundle\TranslationBundle\EventDispatcher\Event;
 
 use Symfony\Component\EventDispatcher\Event;
 

--- a/EventDispatcher/GetDatabaseResourcesListener.php
+++ b/EventDispatcher/GetDatabaseResourcesListener.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Lexik\Bundle\TranslationBundle\Translation;
+namespace Lexik\Bundle\TranslationBundle\EventDispatcher;
 
+use Lexik\Bundle\TranslationBundle\EventDispatcher\Event\GetDatabaseResourcesEvent;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 
 /**

--- a/Propel/TransUnitRepository.php
+++ b/Propel/TransUnitRepository.php
@@ -49,6 +49,8 @@ class TransUnitRepository
     /**
      * Returns all domains for each locale.
      *
+     * @param string $locale
+     * @param string $domain
      * @return array
      */
     public function getAllByLocaleAndDomain($locale, $domain)
@@ -69,8 +71,6 @@ class TransUnitRepository
     /**
      * Returns all trans unit with translations for the given domain and locale.
      *
-     * @param string $locale
-     * @param string $domain
      * @return array
      */
     public function getAllDomains()

--- a/Propel/TranslationRepository.php
+++ b/Propel/TranslationRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Propel;
+
+/**
+ * Repository for Translation entity (Propel).
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class TranslationRepository
+{
+    /**
+     * @var \PDO
+     */
+    protected $connection;
+
+    /**
+     * @param \PDO $connection
+     */
+    public function __construct(\PDO $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @return \PDO
+     */
+    protected function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getLatestTranslationUpdatedAt()
+    {
+        $result = TranslationQuery::create()
+            ->withColumn(sprintf('MAX(%s)', TranslationPeer::UPDATED_AT), 'max_updated_at')
+            ->select(array('max_updated_at'))
+            ->findOne($this->getConnection())
+        ;
+
+        return !empty($result) ? new \DateTime($result) : null;
+    }
+}

--- a/Resources/config/doctrine/Translation.orm.xml
+++ b/Resources/config/doctrine/Translation.orm.xml
@@ -4,8 +4,9 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Lexik\Bundle\TranslationBundle\Entity\Translation" 
-            table="lexik_trans_unit_translations">
+    <entity name="Lexik\Bundle\TranslationBundle\Entity\Translation"
+            table="lexik_trans_unit_translations"
+            repository-class="Lexik\Bundle\TranslationBundle\Entity\TranslationRepository">
 
         <unique-constraints>
             <unique-constraint name="trans_unit_locale_idx" columns="trans_unit_id,locale" />
@@ -15,15 +16,15 @@
             <lifecycle-callback type="prePersist" method="prePersist" />
             <lifecycle-callback type="preUpdate" method="preUpdate" />
         </lifecycle-callbacks>
-        
+
         <id name="id" type="integer" column="id">
             <generator strategy="IDENTITY"/>
         </id>
-        
+
         <many-to-one field="file" target-entity="Lexik\Bundle\TranslationBundle\Entity\File" inversed-by="translations">
             <join-column name="file_id" referenced-column-name="id" />
         </many-to-one>
-        
+
         <many-to-one field="transUnit" target-entity="Lexik\Bundle\TranslationBundle\Entity\TransUnit" inversed-by="translations">
             <join-column name="trans_unit_id" referenced-column-name="id" />
         </many-to-one>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,7 @@
         <parameter key="lexik_translation.form.handler.trans_unit.class">Lexik\Bundle\TranslationBundle\Form\Handler\TransUnitFormHandler</parameter>
 
         <parameter key="lexik_translation.listener.get_database_resources.class">Lexik\Bundle\TranslationBundle\Translation\GetDatabaseResourcesListener</parameter>
+        <parameter key="lexik_translation.listener.clean_translation_cache.class">Lexik\Bundle\TranslationBundle\EventDispatcher\CleanTranslationCacheListener</parameter>
     </parameters>
 
     <services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -37,7 +37,7 @@
         <parameter key="lexik_translation.form.type.translation.class">Lexik\Bundle\TranslationBundle\Form\Type\TranslationType</parameter>
         <parameter key="lexik_translation.form.handler.trans_unit.class">Lexik\Bundle\TranslationBundle\Form\Handler\TransUnitFormHandler</parameter>
 
-        <parameter key="lexik_translation.listener.get_database_resources.class">Lexik\Bundle\TranslationBundle\Translation\GetDatabaseResourcesListener</parameter>
+        <parameter key="lexik_translation.listener.get_database_resources.class">Lexik\Bundle\TranslationBundle\EventDispatcher\GetDatabaseResourcesListener</parameter>
         <parameter key="lexik_translation.listener.clean_translation_cache.class">Lexik\Bundle\TranslationBundle\EventDispatcher\CleanTranslationCacheListener</parameter>
     </parameters>
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -64,6 +64,7 @@ lexik_translation:
     resources_registration:
         type:                 all     # resources type to register: "all", "files" or "database"
         managed_locales_only: true    # will only load resources for managed locales
+    auto_cache_clean: false     # set to true to make the bundle automatically clear translations cache files
 ```
 
 *Note that MongoDB 2.0.0 or later is required if you choose to use MongoDB to store translations.*

--- a/Resources/public/js/translation.js
+++ b/Resources/public/js/translation.js
@@ -24,6 +24,7 @@ app.controller('TranslationController', [
 
         $scope.locales = translationCfg.locales;
         $scope.editType = translationCfg.inputType;
+        $scope.autoCacheClean = translationCfg.autoCacheClean;
         $scope.hideColBtnLabel = translationCfg.label.hideCol;
         $scope.invalidateCacheBtnLabel = translationCfg.label.invalidateCache;
         $scope.saveRowBtnLabel = translationCfg.label.saveRow;

--- a/Resources/views/Translation/_ngGrid.html.twig
+++ b/Resources/views/Translation/_ngGrid.html.twig
@@ -7,7 +7,7 @@
                 <span class="glyphicon glyphicon-eye-close"></span>
                 {{ hideColBtnLabel }}
             </a>
-            <a ng-click="invalidateCache()" role="button" class="btn btn-primary btn-sm btn-invalidate-cache">
+            <a ng-show="!autoCacheClean" ng-click="invalidateCache()" role="button" class="btn btn-primary btn-sm btn-invalidate-cache">
                 <span class="glyphicon glyphicon-refresh"></span>
                 {{ invalidateCacheBtnLabel }}
             </a>

--- a/Resources/views/Translation/grid.html.twig
+++ b/Resources/views/Translation/grid.html.twig
@@ -35,6 +35,7 @@
         var translationCfg = {
             locales: {{ locales | json_encode | raw }},
             inputType: '{{ inputType }}',
+            autoCacheClean: {{ autoCacheClean ? 'true' : 'false' }},
             toggleSimilar: '{{ toggleSimilar }}',
             url: {
                 list: '{{ path('lexik_translation_list') }}',

--- a/Storage/DoctrineMongoDBStorage.php
+++ b/Storage/DoctrineMongoDBStorage.php
@@ -9,4 +9,11 @@ namespace Lexik\Bundle\TranslationBundle\Storage;
  */
 class DoctrineMongoDBStorage extends AbstractDoctrineStorage
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getLatestUpdatedAt()
+    {
+        return $this->getTransUnitRepository()->getLatestTranslationUpdatedAt();
+    }
 }

--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -27,4 +27,22 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
 
         return $schemaManager->tablesExist($tables);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLatestUpdatedAt()
+    {
+        return $this->getTranslationRepository()->getLatestTranslationUpdatedAt();
+    }
+
+    /**
+     * Returns the TransUnit repository.
+     *
+     * @return object
+     */
+    protected function getTranslationRepository()
+    {
+        return $this->getManager()->getRepository($this->classes['translation']);
+    }
 }

--- a/Storage/PropelStorage.php
+++ b/Storage/PropelStorage.php
@@ -6,6 +6,7 @@ use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
 use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
 use Lexik\Bundle\TranslationBundle\Propel\TransUnitQuery;
 use Lexik\Bundle\TranslationBundle\Propel\TransUnitRepository;
+use Lexik\Bundle\TranslationBundle\Propel\TranslationRepository;
 
 /**
  * Doctrine ORM storage class.
@@ -38,6 +39,11 @@ class PropelStorage implements StorageInterface
      * @var TransUnitRepository
      */
     private $transUnitRepository;
+
+    /**
+     * @var TranslationRepository
+     */
+    private $translationRepository;
 
     /**
      * @var FileRepository
@@ -242,6 +248,14 @@ class PropelStorage implements StorageInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getLatestUpdatedAt()
+    {
+        return $this->getTranslationRepository()->getLatestTranslationUpdatedAt();
+    }
+
+    /**
      * Returns true if translation tables exist.
      *
      * @return boolean
@@ -284,6 +298,20 @@ class PropelStorage implements StorageInterface
         }
 
         return $this->transUnitRepository;
+    }
+
+    /**
+     * Returns the TransUnit repository.
+     *
+     * @return TranslationRepository
+     */
+    protected function getTranslationRepository()
+    {
+        if (null === $this->translationRepository) {
+            $this->translationRepository = new TranslationRepository($this->getConnection());
+        }
+
+        return $this->translationRepository;
     }
 
     /**

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -130,4 +130,11 @@ interface StorageInterface
      * @return array
      */
     public function getTranslationsFromFile($file, $onlyUpdated);
+
+    /**
+     * Returns the latest updatedAt date among all translation.
+     *
+     * @return \DateTime|null
+     */
+    public function getLatestUpdatedAt();
 }

--- a/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Repository\Propel;
 
-use Lexik\Bundle\TranslationBundle\Propel\TranslationRepository;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 use Lexik\Bundle\TranslationBundle\Propel\TransUnitRepository;
 use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
@@ -215,10 +214,6 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
             'key.say_goodbye' => 'au revoir',
         );
         $this->assertEquals($expected, $result);
-
-
-        $repository = new TranslationRepository($con);
-        var_dump($repository->getLatestTranslationUpdatedAt());
     }
 
     protected function assertSameTransUnit($expected, $result)

--- a/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Repository\Propel;
 
+use Lexik\Bundle\TranslationBundle\Propel\TranslationRepository;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 use Lexik\Bundle\TranslationBundle\Propel\TransUnitRepository;
 use Lexik\Bundle\TranslationBundle\Propel\FileRepository;
@@ -214,6 +215,10 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
             'key.say_goodbye' => 'au revoir',
         );
         $this->assertEquals($expected, $result);
+
+
+        $repository = new TranslationRepository($con);
+        var_dump($repository->getLatestTranslationUpdatedAt());
     }
 
     protected function assertSameTransUnit($expected, $result)

--- a/Tests/Unit/Translation/TranslatorTest.php
+++ b/Tests/Unit/Translation/TranslatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Translation;
 
-use Lexik\Bundle\TranslationBundle\Translation\GetDatabaseResourcesListener;
+use Lexik\Bundle\TranslationBundle\EventDispatcher\GetDatabaseResourcesListener;
 use Lexik\Bundle\TranslationBundle\Translation\Translator;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 

--- a/Translation/DatabaseFreshResource.php
+++ b/Translation/DatabaseFreshResource.php
@@ -33,8 +33,7 @@ class DatabaseFreshResource implements ResourceInterface
     }
 
     /**
-     * (non-PHPdoc)
-     * @see Symfony\Component\Config\Resource.ResourceInterface::__toString()
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -42,8 +41,7 @@ class DatabaseFreshResource implements ResourceInterface
     }
 
     /**
-     * (non-PHPdoc)
-     * @see Symfony\Component\Config\Resource.ResourceInterface::isFresh()
+     * {@inheritdoc}
      */
     public function isFresh($timestamp)
     {
@@ -51,8 +49,7 @@ class DatabaseFreshResource implements ResourceInterface
     }
 
     /**
-     * (non-PHPdoc)
-     * @see Symfony\Component\Config\Resource.ResourceInterface::getResource()
+     * {@inheritdoc}
      */
     public function getResource()
     {

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Translation;
 
+use Lexik\Bundle\TranslationBundle\EventDispatcher\Event\GetDatabaseResourcesEvent;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -15,7 +15,6 @@ class Translator extends BaseTranslator
 {
     /**
      * Add all resources available in database.
-     *
      */
     public function addDatabaseResources()
     {


### PR DESCRIPTION
Related to https://github.com/lexik/LexikTranslationBundle/issues/124.

Todo:
* [x] Add an `auto_cache_clean` option to load a listner.
* [x] Add method into Doctrine/Propel storage classes to get latest updatedAt.
* [x] If `auto_cache_clean` is true hide the button on the grid.
* [x] Move `GetDatabaseResourcesEvent` and `GetDatabaseResourcesListener` into `EventDispatcher/` folder.