### PR TITLE
Import/export enhancements

### DIFF
--- a/Command/ExportTranslationsCommand.php
+++ b/Command/ExportTranslationsCommand.php
@@ -88,7 +88,7 @@ class ExportTranslationsCommand extends ContainerAwareCommand
 
         // we only export updated translations in case of the file is located in vendor/
         $onlyUpdated = $override ?
-            ( false === strpos($file->getPath(), 'app/Resources/') ) :
+            ( 'Resources/translations' !== $file->getPath() ) :
             ( false !== strpos($file->getPath(), 'vendor/') );
 
         $translations = $this->getContainer()
@@ -123,7 +123,8 @@ class ExportTranslationsCommand extends ContainerAwareCommand
     protected function mergeExistingTranslations($file, $outputFile, $translations)
     {
         if (file_exists($outputFile)) {
-            $loader = $this->getContainer()->get('lexik_translation.translator')->getLoader($file->getExtention());
+            $extension = pathinfo($outputFile, PATHINFO_EXTENSION);
+            $loader = $this->getContainer()->get('lexik_translation.translator')->getLoader($extension);
             $messageCatalogue = $loader->load($outputFile, $file->getLocale(), $file->getDomain());
 
             $translations = array_merge($messageCatalogue->all($file->getDomain()), $translations);

--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -42,6 +42,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
         $this->addOption('globals', 'g', InputOption::VALUE_NONE, 'Import only globals (app/Resources/translations.');
         $this->addOption('locales', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Import only for these locales, instead of using the managed locales.');
         $this->addOption('domains', 'd', InputOption::VALUE_OPTIONAL, 'Only imports files for given domains (comma separated).');
+        $this->addOption('merge', 'm', InputOption::VALUE_NONE, 'Merge translation (use ones with latest updatedAt date).');
 
         $this->addArgument('bundle', InputArgument::OPTIONAL,'Import translations for this specific bundle.', null);
     }
@@ -165,7 +166,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
 
             foreach ($finder as $file)  {
                 $this->output->write(sprintf('Importing <comment>"%s"</comment> ... ', $file->getPathname()));
-                $number = $importer->import($file, $this->input->getOption('force'));
+                $number = $importer->import($file, $this->input->getOption('force'), $this->input->getOption('merge'));
                 $this->output->writeln(sprintf('%d translations', $number));
             }
         } else {

--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -67,8 +67,10 @@ class ImportTranslationsCommand extends ContainerAwareCommand
             $bundle = $this->getApplication()->getKernel()->getBundle($bundleName);
             $this->importBundleTranslationFiles($bundle, $locales, $domains);
         } else {
-            $this->output->writeln('<info>*** Importing application translation files ***</info>');
-            $this->importAppTranslationFiles($locales, $domains);
+            if (!$this->input->getOption('merge')) {
+                $this->output->writeln('<info>*** Importing application translation files ***</info>');
+                $this->importAppTranslationFiles($locales, $domains);
+            }
 
             if (!$this->input->getOption('globals')) {
                 $this->output->writeln('<info>*** Importing bundles translation files ***</info>');
@@ -76,6 +78,11 @@ class ImportTranslationsCommand extends ContainerAwareCommand
 
                 $this->output->writeln('<info>*** Importing component translation files ***</info>');
                 $this->importComponentTranslationFiles($locales, $domains);
+            }
+
+            if ($this->input->getOption('merge')) {
+                $this->output->writeln('<info>*** Importing application translation files ***</info>');
+                $this->importAppTranslationFiles($locales, $domains);
             }
         }
 

--- a/Entity/Translation.php
+++ b/Entity/Translation.php
@@ -59,8 +59,9 @@ class Translation extends TranslationModel implements TranslationInterface
      */
     public function prePersist()
     {
-        $this->createdAt = new \DateTime("now");
-        $this->updatedAt = new \DateTime("now");
+        $now             = new \DateTime("now");
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
     }
 
     /**

--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -138,6 +138,8 @@ class TransUnitManager implements TransUnitManagerInterface
 
                 $newTranslation = clone $translation;
                 $this->storage->remove($translation);
+                $this->storage->flush();
+
                 $newTranslation->setContent($content);
                 $this->storage->persist($newTranslation);
                 $translation = $newTranslation;

--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Manager;
 
+use Lexik\Bundle\TranslationBundle\Model\Translation;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Storage\PropelStorage;
 
@@ -112,7 +113,7 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false)
+    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false, $merge = false, \DateTime $modifiedOn = null)
     {
         $translation = null;
         $i = 0;
@@ -125,7 +126,22 @@ class TransUnitManager implements TransUnitManagerInterface
         }
 
         if ($found) {
+            /* @var Translation $translation */
             $translation = $transUnit->getTranslations()->get($i-1);
+            if ($merge) {
+                if ($translation->getContent() == $content) {
+                    return null;
+                }
+                if ($translation->getCreatedAt() != $translation->getUpdatedAt() && (!$modifiedOn || $translation->getUpdatedAt() > $modifiedOn)) {
+                    return null;
+                }
+
+                $newTranslation = clone $translation;
+                $this->storage->remove($translation);
+                $newTranslation->setContent($content);
+                $this->storage->persist($newTranslation);
+                $translation = $newTranslation;
+            }
             $translation->setContent($content);
         }
 

--- a/Manager/TransUnitManagerInterface.php
+++ b/Manager/TransUnitManagerInterface.php
@@ -46,9 +46,11 @@ interface TransUnitManagerInterface
      * @param string                $locale
      * @param string                $content
      * @param boolean               $flush
+     * @param boolean               $merge
+     * @param \DateTime|null        $modifiedOn
      * @return TranslationInterface
      */
-    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false);
+    public function updateTranslation(TransUnitInterface $transUnit, $locale, $content, $flush = false, $merge = false, \DateTime $modifiedOn = null);
 
     /**
      * Update the content of each translations for the given trans unit.

--- a/Storage/AbstractDoctrineStorage.php
+++ b/Storage/AbstractDoctrineStorage.php
@@ -79,6 +79,14 @@ abstract class AbstractDoctrineStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
+    public function remove($entity)
+    {
+        $this->getManager()->remove($entity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function flush($entity = null)
     {
         $this->getManager()->flush($entity);

--- a/Storage/PropelStorage.php
+++ b/Storage/PropelStorage.php
@@ -109,6 +109,14 @@ class PropelStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
+    public function remove($entity)
+    {
+        // @TODO: implement
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function flush($entity = null)
     {
         if (null === $entity) {

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -19,6 +19,13 @@ interface StorageInterface
     public function persist($entity);
 
     /**
+     * Delete the given object.
+     *
+     * @param object $entity
+     */
+    public function remove($entity);
+
+    /**
      * Flush changes.
      *
      * @param string $entity

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -57,9 +57,10 @@ class FileImporter
      *
      * @param \Symfony\Component\Finder\SplFileInfo $file
      * @param boolean                               $forceUpdate  force update of the translations
+     * @param boolean                               $merge        merge translations
      * @return int
      */
-    public function import(\Symfony\Component\Finder\SplFileInfo $file, $forceUpdate = false)
+    public function import(\Symfony\Component\Finder\SplFileInfo $file, $forceUpdate = false, $merge = false)
     {
         $imported = 0;
         list($domain, $locale, $extention) = explode('.', $file->getFilename());
@@ -86,6 +87,11 @@ class FileImporter
                 } else if($forceUpdate) {
                     $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content);
                     $imported++;
+                } else if($merge) {
+                    $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content, false, true);
+                    if ($translation instanceof TranslationInterface) {
+                        $imported++;
+                    }
                 }
 
                 // convert MongoTimestamp objects to time to don't get an error in:

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -62,9 +62,13 @@ class Translator extends BaseTranslator
             if (!unlink($file)) {
                 $deleted = false;
             }
+            else {
+                $this->invalidateSystemCacheForFile($file);
+            }
             $metadata = $file.'.meta';
             if (file_exists($metadata)) {
                 unlink($metadata);
+                $this->invalidateSystemCacheForFile($metadata);
             }
         }
 


### PR DESCRIPTION
Added import merge & export override options.

When export override option is specified, only translations that were modified in DB are exported + all translations that were previously imported from app/Resources/translations.

When import merge option is specified, than DB translations that were modified (createdAt != updatedAt) are skipped during import (so db modifications aren't overwritten).

Also, added APC/OPcache invalidation after translation cache file delete.