### PR TITLE
Fix possible SQL injection

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -199,8 +199,11 @@ class TransUnitRepository extends EntityRepository
 
             foreach ($locales as $locale) {
                 if (!empty($filters[$locale])) {
-                    $qb->andWhere($qb->expr()->like('t.content', sprintf("'%%%s%%'", $filters[$locale])));
-                    $qb->andWhere($qb->expr()->eq('t.locale', sprintf("'%s'", $locale)));
+                    $qb->andWhere($qb->expr()->like('t.content', ':content'))
+                        ->setParameter('content', sprintf('%%%s%%', $filters[$locale]));
+
+                    $qb->andWhere($qb->expr()->eq('t.locale', ':locale'))
+                        ->setParameter('locale', sprintf('%s', $locale));
                 }
             }
 


### PR DESCRIPTION
Currently we can get an error when adding a simple quote ``'`` in a content form filter.

Sample:
[2015-05-15 17:54:26] request.CRITICAL: Uncaught PHP Exception Doctrine\ORM\Query\QueryException: "[Syntax Error] line 0, col 163: Error: Expected end of string, got '%'" at xxx/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php line 52 {"exception":"[object] (Doctrine\\ORM\\Query\\QueryException(code: 0): [Syntax Error] line 0, col 163: Error: Expected end of string, got '%' at xxx/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:52, Doctrine\\ORM\\Query\\QueryException(code: 0): SELECT DISTINCT tu.id FROM Lexik\\Bundle\\TranslationBundle\\Entity\\TransUnit tu LEFT JOIN tu.translations t WHERE t.locale IN('en', 'fr') AND t.content LIKE '%test '%' AND t.locale = 'fr' at xxx/vendor/doctrine/orm/lib/Doctrine/ORM/Query/QueryException.php:41)"} []
