### PR TITLE
Replace deprecated options in routing

### DIFF
--- a/Resources/config/routing/api.yml
+++ b/Resources/config/routing/api.yml
@@ -1,9 +1,9 @@
 lexik_translation_list:
-    pattern:      /translations
-    defaults:     { _controller: "LexikTranslationBundle:Rest:list" }
-    requirements: { _method: GET }
+    path:     /translations
+    defaults: { _controller: "LexikTranslationBundle:Rest:list" }
+    methods:  [GET]
 
 lexik_translation_update:
-    pattern:      /translations/{id}
-    defaults:     { _controller: "LexikTranslationBundle:Rest:update" }
-    requirements: { _method: PUT }
+    path:     /translations/{id}
+    defaults: { _controller: "LexikTranslationBundle:Rest:update" }
+    methods:  [PUT]

--- a/Resources/config/routing/app.yml
+++ b/Resources/config/routing/app.yml
@@ -1,14 +1,14 @@
 lexik_translation_grid:
-    pattern:      /grid
-    defaults:     { _controller: "LexikTranslationBundle:Translation:grid" }
-    requirements: { _method: GET }
+    path:     /grid
+    defaults: { _controller: "LexikTranslationBundle:Translation:grid" }
+    methods:  [GET]
 
 lexik_translation_new:
-    pattern:  /new
+    path:     /new
     defaults: { _controller: "LexikTranslationBundle:Translation:new" }
-    requirements: { _method: GET|POST }
+    methods:  [GET, POST]
 
 lexik_translation_invalidate_cache:
-    pattern:  /invalidate-cache
+    path:     /invalidate-cache
     defaults: { _controller: "LexikTranslationBundle:Translation:invalidateCache" }
-    requirements: { _method: GET }
+    methods:  [GET]


### PR DESCRIPTION
Replace options deprecated since Symfony 2.2 by the current ones.