### PR TITLE
Add cache expiration interval

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,6 +68,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(false)
                 ->end()
 
+                ->integerNode('auto_cache_clean_interval')
+                    ->defaultValue(null)
+                ->end()
+
                 ->arrayNode('storage')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -51,7 +51,7 @@ class LexikTranslationExtension extends Extension
         $this->buildTranslationStorageDefinition($container, $config['storage']['type'], $objectManager);
 
         if (true === $config['auto_cache_clean']) {
-            $this->buildCacheCleanListenerDefinition($container);
+            $this->buildCacheCleanListenerDefinition($container, $config['auto_cache_clean_interval']);
         }
 
         $this->registerTranslatorConfiguration($config, $container);
@@ -59,8 +59,9 @@ class LexikTranslationExtension extends Extension
 
     /**
      * @param ContainerBuilder $container
+     * @param int $cacheInterval
      */
-    public function buildCacheCleanListenerDefinition(ContainerBuilder $container)
+    public function buildCacheCleanListenerDefinition(ContainerBuilder $container, $cacheInterval)
     {
         $listener = new Definition();
         $listener->setClass('%lexik_translation.listener.clean_translation_cache.class%');
@@ -69,6 +70,7 @@ class LexikTranslationExtension extends Extension
         $listener->addArgument(new Reference('translator'));
         $listener->addArgument(new Parameter('kernel.cache_dir'));
         $listener->addArgument(new Parameter('lexik_translation.managed_locales'));
+        $listener->addArgument($cacheInterval);
 
         $listener->addTag('kernel.event_listener', array(
             'event'  => 'kernel.request',

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -65,6 +65,7 @@ lexik_translation:
         type:                 all     # resources type to register: "all", "files" or "database"
         managed_locales_only: true    # will only load resources for managed locales
     auto_cache_clean: false     # set to true to make the bundle automatically clear translations cache files
+    auto_cache_clean_interval: 600     # The number of seconds to wait before trying to check if translations have changed in the database.
 ```
 
 *Note that MongoDB 2.0.0 or later is required if you choose to use MongoDB to store translations.*

--- a/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
+++ b/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Tests\Unit\EventDispatcher;
+
+use Lexik\Bundle\TranslationBundle\EventDispatcher\CleanTranslationCacheListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Unit test for CleanTranslationCacheListener class
+ *
+ * @author Max Milazzo maxmilazzo@timeout.com
+ */
+class CleanTranslationCacheListenerTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $tempDir;
+
+    public function setUp()
+    {
+        $this->tempDir = \sys_get_temp_dir() . '/translations';
+    }
+
+    public function testDefaultLocale()
+    {
+        $request = Request::create('/');
+
+        $date = new \DateTime;
+
+        if (!\file_exists($this->tempDir)) {
+            \mkdir($this->tempDir);
+        }
+
+        \touch($this->tempDir . '/messages.en.yml', time() - 3600);
+
+        $storage = $this->getMockBuilder('Lexik\Bundle\TranslationBundle\Storage\StorageInterface')
+                ->disableOriginalConstructor()
+                ->setMethods(array())
+                ->getMock();
+
+        $storage->expects($this->any())->method('getLatestUpdatedAt')->will($this->returnValue($date));
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $translator = $this->getMock('Lexik\Bundle\TranslationBundle\Translation\Translator', array(), array($container, new MessageSelector));
+
+        $translator->expects($this->any())->method('removeLocalesCacheFiles')->will($this->returnValue(true));
+
+        $listener = new CleanTranslationCacheListener($storage, $translator, \sys_get_temp_dir(), array('en'), 600);
+
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertTrue(file_exists($this->tempDir . '/cache_timestamp'));
+        $this->assertEquals(1, $this->countFiles($date));
+
+        \touch($this->tempDir . '/messages.en.yml');
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals(0, $this->countFiles($date));
+    }
+
+    private function getEvent(Request $request)
+    {
+        return new GetResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST);
+    }
+
+    private function countFiles($lastUpdateTime)
+    {
+        $finder = new Finder();
+        $finder->files()
+                ->in($this->tempDir)
+                ->date('< ' . $lastUpdateTime->format('Y-m-d H:i:s'));
+
+        return $finder->count();
+    }
+
+    public function tearDown()
+    {
+        \array_map('unlink', \glob($this->tempDir . "/*"));
+    }
+
+}


### PR DESCRIPTION
@cedric-g - we are using this now on our production platform. This configuration option saves on hitting the db every request when checking for new translations.

As per https://github.com/lexik/LexikTranslationBundle/pull/153