### PR TITLE
Prevent SQL error while search includes quote

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -202,7 +202,7 @@ class TransUnitRepository extends EntityRepository
 
             foreach ($locales as $locale) {
                 if (!empty($filters[$locale])) {
-                    $qb->andWhere($qb->expr()->like('t.content', sprintf("'%%%s%%'", $filters[$locale])));
+                    $qb->andWhere($qb->expr()->like('t.content', $qb->expr()->literal(sprintf("'%%%s%%'", $filters[$locale]))));
                     $qb->andWhere($qb->expr()->eq('t.locale', sprintf("'%s'", $locale)));
                 }
             }


### PR DESCRIPTION
Please, also note that "data" has never an "s" on plural form. Even if it is an array of data !