### PR TITLE
Added manager to handle locales dynamically

### DIFF
--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -81,6 +81,6 @@ class TranslationController extends Controller
      */
     protected function getManagedLocales()
     {
-        return $this->container->getParameter('lexik_translation.managed_locales');
+        return $this->get('lexik_translation.locale.manager')->getLocales();
     }
 }

--- a/Form/Handler/TransUnitFormHandler.php
+++ b/Form/Handler/TransUnitFormHandler.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Form\Handler;
 
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitManagerInterface;
 use Lexik\Bundle\TranslationBundle\Manager\FileInterface;
 use Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface;
@@ -31,9 +32,9 @@ class TransUnitFormHandler implements FormHandlerInterface
     protected $storage;
 
     /**
-     * @var array
+     * @var LocaleManagerInterface
      */
-    protected $managedLocales;
+    protected $localeManager;
 
     /**
      * @var string
@@ -44,15 +45,15 @@ class TransUnitFormHandler implements FormHandlerInterface
      * @param TransUnitManagerInterface $transUnitManager
      * @param FileManagerInterface      $fileManager
      * @param StorageInterface          $storage
-     * @param array                     $managedLocales
+     * @param LocaleManagerInterface    $localeManager
      * @param string                    $rootDir
      */
-    public function __construct(TransUnitManagerInterface $transUnitManager, FileManagerInterface $fileManager, StorageInterface $storage, array $managedLocales, $rootDir)
+    public function __construct(TransUnitManagerInterface $transUnitManager, FileManagerInterface $fileManager, StorageInterface $storage, LocaleManagerInterface $localeManager, $rootDir)
     {
         $this->transUnitManager = $transUnitManager;
         $this->fileManager = $fileManager;
         $this->storage = $storage;
-        $this->managedLocales = $managedLocales;
+        $this->localeManager = $localeManager;
         $this->rootDir = $rootDir;
     }
 
@@ -61,7 +62,7 @@ class TransUnitFormHandler implements FormHandlerInterface
      */
     public function createFormData()
     {
-        return $this->transUnitManager->newInstance($this->managedLocales);
+        return $this->transUnitManager->newInstance($this->localeManager->getLocales());
     }
 
     /**

--- a/Manager/LocaleManager.php
+++ b/Manager/LocaleManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Manager;
+
+/**
+ * Manager for translations files.
+ */
+class LocaleManager implements LocaleManagerInterface
+{
+    /**
+     * @var array
+     */
+    protected $managedLocales;
+
+    /**
+     * Constructor
+     *
+     * @param array $managedLocales
+     */
+    public function __construct(array $managedLocales)
+    {
+        $this->managedLocales = $managedLocales;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLocales()
+    {
+        return $this->managedLocales;
+    }
+}

--- a/Manager/LocaleManagerInterface.php
+++ b/Manager/LocaleManagerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Manager;
+
+/**
+ * Locale manager interface.
+ */
+interface LocaleManagerInterface
+{
+    /**
+     * @return array
+     */
+    public function getLocales();
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="lexik_translation.loader.database.class">Lexik\Bundle\TranslationBundle\Translation\Loader\DatabaseLoader</parameter>
         <parameter key="lexik_translation.trans_unit.manager.class">Lexik\Bundle\TranslationBundle\Manager\TransUnitManager</parameter>
         <parameter key="lexik_translation.file.manager.class">Lexik\Bundle\TranslationBundle\Manager\FileManager</parameter>
+        <parameter key="lexik_translation.locale.manager.class">Lexik\Bundle\TranslationBundle\Manager\LocaleManager</parameter>
         <parameter key="lexik_translation.importer.file.class">Lexik\Bundle\TranslationBundle\Translation\Importer\FileImporter</parameter>
         <parameter key="lexik_translation.exporter_collector.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\ExporterCollector</parameter>
         <parameter key="lexik_translation.exporter.xliff.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\XliffExporter</parameter>
@@ -75,6 +76,10 @@
             <argument>%kernel.root_dir%</argument>
         </service>
 
+        <service id="lexik_translation.locale.manager" class="%lexik_translation.locale.manager.class%">
+            <argument>%lexik_translation.managed_locales%</argument>
+        </service>
+
         <!-- Importer -->
         <service id="lexik_translation.importer.file" class="%lexik_translation.importer.file.class%">
             <argument type="collection" /> <!-- translation loaders -->
@@ -104,14 +109,14 @@
 
         <!-- Data grid -->
         <service id="lexik_translation.data_grid.formatter" class="%lexik_translation.data_grid.formatter.class%">
-            <argument>%lexik_translation.managed_locales%</argument>
+            <argument type="service" id="lexik_translation.locale.manager" />
             <argument>%lexik_translation.storage.type%</argument>
         </service>
 
         <service id="lexik_translation.data_grid.request_handler" class="%lexik_translation.data_grid.request_handler.class%">
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.translation_storage" />
-            <argument>%lexik_translation.managed_locales%</argument>
+            <argument type="service" id="lexik_translation.locale.manager" />
         </service>
 
         <!-- Form -->
@@ -127,7 +132,7 @@
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.file.manager" />
             <argument type="service" id="lexik_translation.translation_storage" />
-            <argument>%lexik_translation.managed_locales%</argument>
+            <argument type="service" id="lexik_translation.locale.manager" />
             <argument>%kernel.root_dir%</argument>
         </service>
 

--- a/Util/DataGrid/DataGridFormatter.php
+++ b/Util/DataGrid/DataGridFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Util\DataGrid;
 
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
@@ -14,9 +15,9 @@ class DataGridFormatter
     /**
      * Managed locales.
      *
-     * @var array
+     * @var LocaleManagerInterface
      */
-    protected $locales;
+    protected $localeManager;
 
     /**
      * Storage type
@@ -28,12 +29,12 @@ class DataGridFormatter
     /**
      * Constructor.
      *
-     * @param array  $locales
+     * @param LocaleManagerInterface  $localeManager
      * @param string $storage
      */
-    public function __construct(array $locales, $storage)
+    public function __construct(LocaleManagerInterface $localeManager, $storage)
     {
-        $this->locales = $locales;
+        $this->localeManager = $localeManager;
         $this->storage = $storage;
     }
 
@@ -101,13 +102,13 @@ class DataGridFormatter
         );
 
         // add locales in the same order as in managed_locales param
-        foreach ($this->locales as $locale) {
+        foreach ($this->localeManager->getLocales() as $locale) {
             $formatted[$locale] = '';
         }
 
         // then fill locales value
         foreach ($transUnit['translations'] as $translation) {
-            if (in_array($translation['locale'], $this->locales)) {
+            if (in_array($translation['locale'], $this->localeManager->getLocales())) {
                 $formatted[$translation['locale']] = $translation['content'];
             }
         }

--- a/Util/DataGrid/DataGridRequestHandler.php
+++ b/Util/DataGrid/DataGridRequestHandler.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Util\DataGrid;
 
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Lexik\Bundle\TranslationBundle\Document\TransUnit as TransUnitDocument;
@@ -24,20 +25,20 @@ class DataGridRequestHandler
     protected $storage;
 
     /**
-     * @var array
+     * @var LocaleManagerInterface
      */
-    protected $managedLocales;
+    protected $localeManager;
 
     /**
      * @param TransUnitManagerInterface $transUnitManager
      * @param StorageInterface          $storage
-     * @param array                     $managedLocales
+     * @param LocaleManagerInterface    $localeManager
      */
-    public function __construct(TransUnitManagerInterface $transUnitManager, StorageInterface $storage, array $managedLocales)
+    public function __construct(TransUnitManagerInterface $transUnitManager, StorageInterface $storage, LocaleManagerInterface $localeManager)
     {
         $this->transUnitManager = $transUnitManager;
         $this->storage = $storage;
-        $this->managedLocales = $managedLocales;
+        $this->localeManager = $localeManager;
     }
 
     /**
@@ -60,13 +61,13 @@ class DataGridRequestHandler
         });
 
         $transUnits = $this->storage->getTransUnitList(
-            $this->managedLocales,
+            $this->localeManager->getLocales(),
             $request->query->get('rows', 20),
             $request->query->get('page', 1),
             $parameters
         );
 
-        $count = $this->storage->countTransUnits($this->managedLocales, $parameters);
+        $count = $this->storage->countTransUnits($this->localeManager->getLocales(), $parameters);
 
         return array($transUnits, $count);
     }
@@ -88,7 +89,7 @@ class DataGridRequestHandler
         }
 
         $translationsContent = array();
-        foreach ($this->managedLocales as $locale) {
+        foreach ($this->localeManager->getLocales() as $locale) {
             $translationsContent[$locale] = $request->request->get($locale);
         }
 


### PR DESCRIPTION
I noticed there was no way to add or remove locales dynamically (e.g. from a database), so instead of serving the `managedLocales` directly from the configuration, I created a manager which returns the available locales. This way it's a lot easier to simply extend the manager and serve the available locales from where ever.

If this is something you'd like, I could add some tests and create some documentation on how new users could override the `LocaleManager`.