### PR TITLE
Added JsonExporter

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,6 +13,7 @@
         <parameter key="lexik_translation.importer.file.class">Lexik\Bundle\TranslationBundle\Translation\Importer\FileImporter</parameter>
         <parameter key="lexik_translation.exporter_collector.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\ExporterCollector</parameter>
         <parameter key="lexik_translation.exporter.xliff.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\XliffExporter</parameter>
+        <parameter key="lexik_translation.exporter.json.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\JsonExporter</parameter>
         <parameter key="lexik_translation.exporter.yml.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\YamlExporter</parameter>
         <parameter key="lexik_translation.exporter.php.class">Lexik\Bundle\TranslationBundle\Translation\Exporter\PhpExporter</parameter>
 
@@ -96,6 +97,10 @@
 
         <service id="lexik_translation.exporter.xliff" class="%lexik_translation.exporter.xliff.class%">
             <tag name="lexik_translation.exporter" alias="xlf" />
+        </service>
+
+        <service id="lexik_translation.exporter.json" class="%lexik_translation.exporter.json.class%">
+            <tag name="lexik_translation.exporter" alias="json" />
         </service>
 
         <service id="lexik_translation.exporter.yml" class="%lexik_translation.exporter.yml.class%">

--- a/Tests/Unit/Translation/Exporter/JsonExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/JsonExporterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Translation\Exporter;
+
+use Lexik\Bundle\TranslationBundle\Translation\Exporter\JsonExporter;
+
+/**
+ * JsonExporter tests.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class JsonExporterTest extends \PHPUnit_Framework_TestCase
+{
+    private $outFileName = '/file.out';
+
+    public function tearDown()
+    {
+        if (file_exists(__DIR__.$this->outFileName)) {
+            unlink(__DIR__.$this->outFileName);
+        }
+    }
+
+    /**
+     * @group exporter
+     */
+    public function testExport()
+    {
+        $outFile = __DIR__.$this->outFileName;
+
+        $exporter = new JsonExporter();
+
+        // export empty array
+        $exporter->export($outFile, array());
+        $expectedContent = <<<C
+[]
+C;
+        $this->assertJsonStringEqualsJsonFile($outFile, $expectedContent);
+
+        // export array with values
+        $exporter->export($outFile, array(
+            'key.a' => 'aaa',
+            'key.b' => 'bbb',
+            'key.c' => 'ccc',
+        ));
+        $expectedContent = <<<EOL
+{
+    "key.a": "aaa",
+    "key.b": "bbb",
+    "key.c": "ccc"
+}
+EOL;
+        $this->assertJsonStringEqualsJsonFile($outFile, $expectedContent);
+    }
+}

--- a/Translation/Exporter/JsonExporter.php
+++ b/Translation/Exporter/JsonExporter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Lexik\Bundle\TranslationBundle\Translation\Exporter;
+
+/**
+ * Export translations to a Json file.
+ *
+ * @author Cédric Girard <c.girard@lexik.fr>
+ */
+class JsonExporter implements ExporterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function export($file, $translations)
+    {
+        $bytes = file_put_contents($file, json_encode($translations, JSON_PRETTY_PRINT));
+
+        return ($bytes !== false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function support($format)
+    {
+        return ('json' == $format);
+    }
+}


### PR DESCRIPTION
... so we can use the `json` format in Weblate to enable continuous translation.

Unfortunately Weblate does not support monolingual components in `xliff` yet.

This does replace #173 