### PR TITLE
Update LexikTranslationBundle.nl.yml

### DIFF
--- a/Resources/translations/LexikTranslationBundle.nl.yml
+++ b/Resources/translations/LexikTranslationBundle.nl.yml
@@ -17,7 +17,7 @@ translations:
     update_failed:       "Fout opgetreden bij vertalen van sleutel #%id%."
     back_to_list:        "Terug"
     all_translations:    "Alle"
-    no_translations:     "No translations
+    no_translations:     "No translations"
     profiler:            "Profiler"
     data_source:         "Databron"
     latest_profiles:     "Laatste profiel"


### PR DESCRIPTION
Fix [Symfony\Component\Translation\Exception\InvalidResourceException]                                                               
  Error parsing YAML, invalid file "/server/vendor/lexik/translation-bundle/Resources/translations/LexikTranslationBundle.nl.yml"

Can you tag a new release as 3.1 is now broken for the lexik:translation:import command