### PR TITLE
Add missing timestamp properties to the File model

### DIFF
--- a/Model/File.php
+++ b/Model/File.php
@@ -58,6 +58,16 @@ abstract class File
     protected $translations;
 
     /**
+     * @var \DateTime
+     */
+    protected $createdAt;
+
+    /**
+     * @var \DateTime
+     */
+    protected $updatedAt;
+
+    /**
      * Construct.
      */
     public function __construct()
@@ -219,5 +229,37 @@ abstract class File
     public function getTranslations()
     {
         return $this->translations;
+    }
+
+    /**
+     * @param \DateTime $createdAt
+     */
+    public function setCreatedAt(\DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param \DateTime $updatedAt
+     */
+    public function setUpdatedAt(\DateTime $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
     }
 }

--- a/Resources/config/model/File.orm.xml
+++ b/Resources/config/model/File.orm.xml
@@ -16,5 +16,9 @@
 
         <field name="hash" column="hash" type="string" length="255" />
 
+        <field name="createdAt" column="created_at" type="datetime" nullable="true" />
+
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true" />
+
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
When I tried to add this bundle to a project, Doctrine was complaining that the `createdAt` property does not exist on the `File` entity.

The [pre-persist and pre-update hooks](https://github.com/lexik/LexikTranslationBundle/blob/master/Entity/File.php#L21) attempts to set `createdAt` and `updatedAt` to the current datetime, but these properties are not declared, nor are they mapped. The pull request fixes that.

Note that I've made them nullable because surprisingly no-one has reported this as an issue yet, so I wanted to keep some backwards compatibility.