### PR TITLE
Fix Symfony 2.2 deprecation

### DIFF
--- a/Resources/config/routing/api.yml
+++ b/Resources/config/routing/api.yml
@@ -6,7 +6,7 @@ lexik_translation_list:
 lexik_translation_profiler:
     path:         /translations/profiler/{token}
     defaults:     { _controller: "LexikTranslationBundle:Rest:listByProfile" }
-    requirements: { _method: GET }
+    methods:  [GET]
 
 lexik_translation_update:
     path:     /translations/{id}


### PR DESCRIPTION
The "_method" requirement of route "lexik_translation_profiler" in file "/Users/damienthiesson/NetBeansProjects/steamTradeManager/vendor/lexik/translation-bundle/Resources/config/routing/api.yml" is deprecated since version 2.2 and will be removed in 3.0. Use the "methods" option instead.