### PR TITLE
Fix for complete support of Symfony >= 2.8

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -155,9 +155,9 @@ class ImportTranslationsCommand extends ContainerAwareCommand
     protected function importComponentTranslationFiles(array $locales, array $domains)
     {
         $classes = array(
-            'Symfony\Component\Validator\Validator'                             => '/Resources/translations',
+            'Symfony\Component\Validator\Validation'                            => '/Resources/translations',
             'Symfony\Component\Form\Form'                                       => '/Resources/translations',
-            'Symfony\Component\Security\Core\Exception\AuthenticationException' => '/../../Resources/translations',
+            'Symfony\Component\Security\Core\Exception\AuthenticationException' => '/../Resources/translations',
         );
 
         $dirs = array();

--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -84,7 +84,7 @@ class TranslationController extends Controller
     {
         $handler = $this->get('lexik_translation.form.handler.trans_unit');
 
-        $form = $this->createForm('lxk_trans_unit', $handler->createFormData(), $handler->getFormOptions());
+        $form = $this->createForm('Lexik\Bundle\TranslationBundle\Form\Type\TransUnitType', $handler->createFormData(), $handler->getFormOptions());
 
         if ($handler->process($form, $request)) {
             $message = $this->get('translator')->trans('translations.succesfully_added', array(), 'LexikTranslationBundle');

--- a/Form/Handler/TransUnitFormHandler.php
+++ b/Form/Handler/TransUnitFormHandler.php
@@ -85,7 +85,7 @@ class TransUnitFormHandler implements FormHandlerInterface
         $valid = false;
 
         if ($request->isMethod('POST')) {
-            $form->submit($request);
+            $form->handleRequest($request);
 
             if ($form->isValid()) {
                 $transUnit = $form->getData();

--- a/Form/Type/TransUnitType.php
+++ b/Form/Type/TransUnitType.php
@@ -26,10 +26,10 @@ class TransUnitType extends AbstractType
             'choices' => array_combine($options['domains'], $options['domains']),
         ));
         $builder->add('translations', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'type'     => 'Lexik\Bundle\TranslationBundle\Form\Type\TranslationType',
+            'entry_type'     => 'Lexik\Bundle\TranslationBundle\Form\Type\TranslationType',
             'label'    => 'translations.page_title',
             'required' => false,
-            'options'  => array(
+            'entry_options'  => array(
                 'data_class' => $options['translation_class'],
             ),
         ));

--- a/Form/Type/TransUnitType.php
+++ b/Form/Type/TransUnitType.php
@@ -18,25 +18,25 @@ class TransUnitType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('key', 'text', array(
+        $builder->add('key', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
             'label' => 'translations.key',
         ));
-        $builder->add('domain', 'choice', array(
+        $builder->add('domain', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
             'label'   => 'translations.domain',
             'choices' => array_combine($options['domains'], $options['domains']),
         ));
-        $builder->add('translations', 'collection', array(
-            'type'     => 'lxk_translation',
+        $builder->add('translations', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
+            'type'     => 'Lexik\Bundle\TranslationBundle\Form\Type\TranslationType',
             'label'    => 'translations.page_title',
             'required' => false,
             'options'  => array(
                 'data_class' => $options['translation_class'],
             ),
         ));
-        $builder->add('save', 'submit', array(
+        $builder->add('save', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', array(
             'label' => 'translations.save',
         ));
-        $builder->add('save_add', 'submit', array(
+        $builder->add('save_add', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', array(
             'label' => 'translations.save_add',
         ));
     }
@@ -58,6 +58,14 @@ class TransUnitType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'lxk_trans_unit';
     }

--- a/Form/Type/TranslationType.php
+++ b/Form/Type/TranslationType.php
@@ -20,8 +20,8 @@ class TranslationType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('locale', 'hidden');
-        $builder->add('content', 'textarea', array(
+        $builder->add('locale', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+        $builder->add('content', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
             'required' => false,
         ));
     }
@@ -49,6 +49,14 @@ class TranslationType extends AbstractType
      * {@inheritdoc}
      */
     public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
     {
         return 'lxk_translation';
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -37,8 +37,6 @@
 
         <parameter key="lexik_translation.overview.stats_aggregator.class">Lexik\Bundle\TranslationBundle\Util\Overview\StatsAggregator</parameter>
 
-        <parameter key="lexik_translation.form.type.trans_unit.class">Lexik\Bundle\TranslationBundle\Form\Type\TransUnitType</parameter>
-        <parameter key="lexik_translation.form.type.translation.class">Lexik\Bundle\TranslationBundle\Form\Type\TranslationType</parameter>
         <parameter key="lexik_translation.form.handler.trans_unit.class">Lexik\Bundle\TranslationBundle\Form\Handler\TransUnitFormHandler</parameter>
 
         <parameter key="lexik_translation.listener.get_database_resources.class">Lexik\Bundle\TranslationBundle\EventDispatcher\GetDatabaseResourcesListener</parameter>
@@ -139,14 +137,6 @@
         </service>
 
         <!-- Form -->
-        <service id="lexik_translation.form.type.trans_unit" class="%lexik_translation.form.type.trans_unit.class%">
-            <tag name="form.type" alias="lxk_trans_unit" />
-        </service>
-
-        <service id="lexik_translation.form.type.translation" class="%lexik_translation.form.type.translation.class%">
-            <tag name="form.type" alias="lxk_translation" />
-        </service>
-
         <service id="lexik_translation.form.handler.trans_unit" class="%lexik_translation.form.handler.trans_unit.class%">
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.file.manager" />

--- a/Translation/DatabaseFreshResource.php
+++ b/Translation/DatabaseFreshResource.php
@@ -2,14 +2,14 @@
 
 namespace Lexik\Bundle\TranslationBundle\Translation;
 
-use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
 
 /**
  * Class used to represent a translation resource coming from the database.
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class DatabaseFreshResource implements ResourceInterface
+class DatabaseFreshResource implements SelfCheckingResourceInterface
 {
     /**
      * @var string

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.7|~3.0"
+        "symfony/framework-bundle": "~2.8|~3.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.4,<2.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "symfony/framework-bundle": "~2.7|~3.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.4,<2.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.7"
+        "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.4,<2.5",


### PR DESCRIPTION
Note that this PR break the compatibility with Symfony < 2.8. So I propose you to create a branch 3.x for the current version supporting Symfony =< 2.7 and then merge this PR on master for 4.x new versions.