### PR TITLE
Change getTranslationFile from protected to public

### DIFF
--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -192,7 +192,7 @@ class TransUnitManager implements TransUnitManagerInterface
      *
      * @return FileInterface|null
      */
-    protected function getTranslationFile(TransUnitInterface & $transUnit, $locale)
+    public function getTranslationFile(TransUnitInterface & $transUnit, $locale)
     {
         $file = null;
         foreach ($transUnit->getTranslations() as $translationModel) {


### PR DESCRIPTION
The reasoning behind this change is to be able to do something like this
https://github.com/ibrows/IbrowsSonataTranslationBundle/blob/3aa864d6d08573e0202f322c4c0b6779fa874bcd/Controller/TranslationCRUDController.php#L80
Note that the file is set to `null`. I would want to be able to change this, and set the proper file, but I cannot access `getTranslationFile` directly to get the file to be passed as parameter.

I see that this function is being accessed by `updateTranslationsContent`, that it is protected, but in this case, where we are just adding one translation, it doesn't make sense to use this interface, it would be better to just have access to `getTranslationFile`.