### PR TITLE
Allow parent template to implements their own buttons

### DIFF
--- a/Resources/views/Translation/grid.html.twig
+++ b/Resources/views/Translation/grid.html.twig
@@ -31,8 +31,9 @@
                 </a>
             {% endset %}
             
-            {% set toolbarButtons = toolbarButtons|merge([newTranslationButton, overviewButton]) %}
-        	
+            {% set temporaryButtons = [newTranslationButton, overviewButton] %}
+            {% set toolbarButtons = temporaryButtons|merge(toolbarButtons) %}
+
             <div class="page-header">
                 <h1>
                     {{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}

--- a/Resources/views/Translation/grid.html.twig
+++ b/Resources/views/Translation/grid.html.twig
@@ -12,18 +12,34 @@
 {% block content %}
     <div class="container">
         {% block toolbar %}
+        	
+			{% if toolbarButtons is not defined %}
+				{% set toolbarButtons = [] %}
+			{% endif %}
+			
+			{% set newTranslationButton %}
+                <a href="{{ path('lexik_translation_new') }}" role="button" class="btn btn-success">
+                    <span class="glyphicon glyphicon-plus"></span>
+                    {{ 'translations.new_translation'|trans({}, 'LexikTranslationBundle') }}
+                </a>
+            {% endset %}
+			
+			{% set overviewButton %}
+                <a href="{{ path('lexik_translation_overview') }}" role="button" class="btn btn-primary">
+                    <span class="glyphicon glyphicon-tasks"></span>
+                    {{ 'overview.page_title'|trans({}, 'LexikTranslationBundle') }}
+                </a>
+            {% endset %}
+            
+            {% set toolbarButtons = toolbarButtons|merge([newTranslationButton, overviewButton]) %}
+        	
             <div class="page-header">
                 <h1>
                     {{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}
                     <div class="pull-right">
-                        <a href="{{ path('lexik_translation_new') }}" role="button" class="btn btn-success">
-                            <span class="glyphicon glyphicon-plus"></span>
-                            {{ 'translations.new_translation'|trans({}, 'LexikTranslationBundle') }}
-                        </a>
-                        <a href="{{ path('lexik_translation_overview') }}" role="button" class="btn btn-primary">
-                            <span class="glyphicon glyphicon-tasks"></span>
-                            {{ 'overview.page_title'|trans({}, 'LexikTranslationBundle') }}
-                        </a>
+                        {% for button in toolbarButtons %}
+                        	{{ button }}
+                        {% endfor %}
                     </div>
                 </h1>
             </div>


### PR DESCRIPTION
By using an array variable, it's possible to inject some behavior from the parent templates of the LexikTranslationBundle template. 
