### PR TITLE
Prefix all the template twig blocks, to avoid conflict

### DIFF
--- a/Resources/views/Translation/grid.html.twig
+++ b/Resources/views/Translation/grid.html.twig
@@ -2,16 +2,16 @@
 
 {% trans_default_domain 'LexikTranslationBundle' %}
 
-{% block stylesheets %}
+{% block lexik_stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/css/translation.css') }}">
 {% endblock %}
 
-{% block title %}{{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}{% endblock %}
+{% block lexik_title %}{{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}{% endblock %}
 
-{% block content %}
+{% block lexik_content %}
     <div class="container">
-        {% block toolbar %}
+        {% block lexik_toolbar %}
             <div class="page-header">
                 <h1>
                     {{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}
@@ -27,15 +27,15 @@
                     </div>
                 </h1>
             </div>
-        {% endblock toolbar %}
+        {% endblock lexik_toolbar %}
 
-        {% block data_grid %}
+        {% block lexik_data_grid %}
             {% include 'LexikTranslationBundle:Translation:_ngGrid.html.twig' %}
-        {% endblock data_grid %}
+        {% endblock lexik_data_grid %}
     </div>
 {% endblock %}
 
-{% block javascript_footer %}
+{% block lexik_javascript_footer %}
     {{ parent() }}
     <script>
         var translationCfg = {

--- a/Resources/views/Translation/new.html.twig
+++ b/Resources/views/Translation/new.html.twig
@@ -1,6 +1,6 @@
 {% extends layout %}
 
-{% block content %}
+{% block lexik_content %}
     <div class="container">
         <div class="row">
             <div class="col-md-12">

--- a/Resources/views/Translation/overview.html.twig
+++ b/Resources/views/Translation/overview.html.twig
@@ -2,16 +2,16 @@
 
 {% trans_default_domain 'LexikTranslationBundle' %}
 
-{% block stylesheets %}
+{% block lexik_stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/css/translation.css') }}">
 {% endblock %}
 
-{% block title %}{{ 'overview.page_title'|trans }}{% endblock %}
+{% block lexik_title %}{{ 'overview.page_title'|trans }}{% endblock %}
 
-{% block content %}
+{% block lexik_content %}
     <div class="container">
-        {% block toolbar %}
+        {% block lexik_toolbar %}
             <div class="page-header">
                 <h1>
                     {{ 'overview.page_title'|trans }}
@@ -23,7 +23,7 @@
                     </div>
                 </h1>
             </div>
-        {% endblock toolbar %}
+        {% endblock lexik_toolbar %}
 
         <p>{{ 'overview.msg_latest_translation'|trans({'%date%': latestTrans|date('Y-m-d H:i')}) }}</p>
 
@@ -78,7 +78,7 @@
     </div>
 {% endblock %}
 
-{% block javascript_footer %}
+{% block lexik_javascript_footer %}
     {{ parent() }}
     <script src="{{ asset('bundles/lexiktranslation/js/translation.js') }}"></script>
 {% endblock %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -2,14 +2,14 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>{% block title %}{% endblock %}</title>
-        {% block stylesheets %}
+        <title>{% block lexik_title %}{% endblock %}</title>
+        {% block lexik_stylesheets %}
             <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
             <link rel="stylesheet" href="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.css') }}">
         {% endblock %}
     </head>
     <body>
-        {% block flash_message %}
+        {% block lexik_flash_message %}
             <div class="container">
                 <div class="row">
                     <div class="col-md-12">
@@ -24,11 +24,11 @@
                     </div>
                 </div>
             </div>
-        {% endblock flash_message %}
+        {% endblock lexik_flash_message %}
 
-        {% block content '' %}
+        {% block lexik_content '' %}
 
-        {% block javascript_footer %}
+        {% block lexik_javascript_footer %}
             <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
             <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular.min.js"></script>
             <script src="{{ asset('bundles/lexiktranslation/ng-table/ng-table.min.js') }}"></script>


### PR DESCRIPTION
Hi,
I recently had conflicts with an integration of the LexikTranslationBundle into a Sonata dashboard (admin bundle).

To resolve the conflict, I think it's a good solution to prefix the twig blocks.

What do you think?