### PR TITLE
Exception fixed for ORM storage

### DIFF
--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -37,7 +37,7 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
             $tmpConnection = DriverManager::getConnection($params);
             try {
                 $dbExists = in_array($connection->getDatabase(), $tmpConnection->getSchemaManager()->listDatabases());
-            } catch (ConnectionException $e) {
+            } catch (\PDOException $e) {
                 $dbExists = false;
             }
             $tmpConnection->close();


### PR DESCRIPTION
Documentation says you allow "doctrine/orm": "~2.4,<2.5" -> but the ConnectionException has been moved, so this only works if you're using 2.5.x. If you add the PDOException instead this issue is sorted.