### PR TITLE
much better finder, fix last PR i did

### DIFF
--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -56,7 +56,7 @@ class Translator extends BaseTranslator
     {
         $localeExploded = explode('_', $locale);
         $finder = new Finder();
-        $finder->files()->in($this->options['cache_dir'])->contains(sprintf('catalogue.*%s*.php', $localeExploded[0]));
+        $finder->files()->in($this->options['cache_dir'])->name(sprintf( '/catalogue\.%s.*\.php$/', $localeExploded[0]));
         $deleted = true;
         foreach ($finder as $file) {
 


### PR DESCRIPTION
contains(sprintf('catalogue.*%s*.php', $localeExploded[0]));
look for content of file

name(sprintf( '/catalogue\.%s.*\.php$/', $localeExploded[0]));
with a much better regex pattern