### PR TITLE
Update service.yml for Symfony3.3

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -60,7 +60,9 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
-            <argument type="service" id="session" on-invalid="ignore" />
+            <argument type="collection">
+                <argument type="service" id="session" on-invalid="ignore" />
+            </argument>
         </service>
 
         <!-- Loader -->


### PR DESCRIPTION
It is an evolution for symfony 3.3.
Argument 5 passed to Symfony\Bundle\FrameworkBundle\Translation\Translator::__construct() must be of the type array, object session given here. I suggest this change to use LexikTranslationBundle in Symfony 3.3.