### PR TITLE
Replace save by saved glyphicon

### DIFF
--- a/Resources/views/Translation/_ngGrid.html.twig
+++ b/Resources/views/Translation/_ngGrid.html.twig
@@ -150,7 +150,7 @@
                     <span class="glyphicon glyphicon-trash"></span>
                 </button>
                 <button ng-show="mode == 'edit'" ng-click="save($event, 'btn-save')" type="button" class="btn btn-success btn-sm">
-                    <span class="glyphicon glyphicon-save"></span>
+                    <span class="glyphicon glyphicon-saved"></span>
                 </button>
                 <button ng-show="mode != null" ng-click="disableMode()" type="button" class="btn btn-warning btn-sm">
                     <span class="glyphicon glyphicon-ban-circle"></span>


### PR DESCRIPTION
Hi,

This is a replacement for save icon by saved, the save icon look like a download action, the saved more like a "confirm" action. What seems more to what is expected.

Link ot icons list : http://getbootstrap.com/components/