### PR TITLE
URL decode updated translation messages

### DIFF
--- a/Util/DataGrid/DataGridRequestHandler.php
+++ b/Util/DataGrid/DataGridRequestHandler.php
@@ -203,7 +203,7 @@ class DataGridRequestHandler
 
         $translationsContent = array();
         foreach ($this->localeManager->getLocales() as $locale) {
-            $translationsContent[$locale] = $request->request->get($locale);
+            $translationsContent[$locale] = urldecode($request->request->get($locale));
         }
 
         $this->transUnitManager->updateTranslationsContent($transUnit, $translationsContent);


### PR DESCRIPTION
Since PR #72, all translation updates are sent URL-encoded to the
backend. To allow spaces and markup in translated messages the
datagrid handler must decode the messages before saving them.

Fixes issue #286