### PR TITLE
Fix double-encoding of translations in the web UI

### DIFF
--- a/Resources/public/js/translation.js
+++ b/Resources/public/js/translation.js
@@ -80,7 +80,7 @@ app.factory('translationApiManager', ['$http', '$httpParamSerializer', function 
 
             var parameters = this.initializeParametersWithCsrf();
             for (var name in translation) {
-                parameters[name] = encodeURIComponent(translation[name]);
+                parameters[name] = translation[name];
             }
 
             // force content type to make SF create a Request with the PUT parameters

--- a/Util/DataGrid/DataGridRequestHandler.php
+++ b/Util/DataGrid/DataGridRequestHandler.php
@@ -203,7 +203,7 @@ class DataGridRequestHandler
 
         $translationsContent = array();
         foreach ($this->localeManager->getLocales() as $locale) {
-            $translationsContent[$locale] = urldecode($request->request->get($locale));
+            $translationsContent[$locale] = $request->request->get($locale);
         }
 
         $this->transUnitManager->updateTranslationsContent($transUnit, $translationsContent);


### PR DESCRIPTION
Commit d95a301 in PR #278 started using angulars
httpParamSerializer component. The serializer does the encoding
required so there's no need for encodeURIComponent.

See #288, #72 