### PR TITLE
Moved container class to layout

### DIFF
--- a/Resources/views/Translation/grid.html.twig
+++ b/Resources/views/Translation/grid.html.twig
@@ -10,15 +10,13 @@
 {% block lexik_title %}{{ 'translations.page_title'|trans({}, 'LexikTranslationBundle') }}{% endblock %}
 
 {% block lexik_content %}
-    <div class="container">
-        {% block lexik_toolbar %}
-            {% include 'LexikTranslationBundle:Translation:_gridToolbar.html.twig' %}
-        {% endblock lexik_toolbar %}
+    {% block lexik_toolbar %}
+        {% include 'LexikTranslationBundle:Translation:_gridToolbar.html.twig' %}
+    {% endblock lexik_toolbar %}
 
-        {% block lexik_data_grid %}
-            {% include 'LexikTranslationBundle:Translation:_ngGrid.html.twig' %}
-        {% endblock lexik_data_grid %}
-    </div>
+    {% block lexik_data_grid %}
+        {% include 'LexikTranslationBundle:Translation:_ngGrid.html.twig' %}
+    {% endblock lexik_data_grid %}
 {% endblock %}
 
 {% block lexik_javascript_footer %}

--- a/Resources/views/Translation/new.html.twig
+++ b/Resources/views/Translation/new.html.twig
@@ -1,57 +1,55 @@
 {% extends layout %}
 
 {% block lexik_content %}
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h3>{{ 'translations.add_translation'|trans({}, 'LexikTranslationBundle') }}</h3>
-                <hr />
+    <div class="row">
+        <div class="col-md-12">
+            <h3>{{ 'translations.add_translation'|trans({}, 'LexikTranslationBundle') }}</h3>
+            <hr />
+        </div>
+
+        <div class="col-md-6">
+
+            {{ form_start(form, {'action': path('lexik_translation_new'), 'method': 'POST', 'attr': {'class': 'form form-vertical'}}) }}
+
+            <div class="form-group">
+                {{ form_label(form.key) }}
+                {{ form_widget(form.key, { 'attr': {'class': 'form-control'} }) }}
+                <span class="text-danger">{{ form_errors(form.key) }}</span>
             </div>
 
-            <div class="col-md-6">
-
-                {{ form_start(form, {'action': path('lexik_translation_new'), 'method': 'POST', 'attr': {'class': 'form form-vertical'}}) }}
-
-                <div class="form-group">
-                    {{ form_label(form.key) }}
-                    {{ form_widget(form.key, { 'attr': {'class': 'form-control'} }) }}
-                    <span class="text-danger">{{ form_errors(form.key) }}</span>
-                </div>
-
-                <div class="form-group">
-                    {{ form_label(form.domain) }}
-                    {{ form_widget(form.domain, { 'attr': {'class': 'form-control'} }) }}
-                    <span class="text-danger">{{ form_errors(form.domain) }}</span>
-                </div>
-
-                <div class="form-group">
-                    {{ form_label(form.translations) }}
-                </div>
-
-                <div class="form-group">
-                    {% for translation in form.translations %}
-                        {{ form_label(translation) }}
-                        {{ form_widget(translation.content, { 'attr': {'class': 'form-control'} }) }}
-                        <span class="text-danger">{{ form_errors(translation.content) }}</span>
-                        {{ form_widget(translation.locale) }}
-                    {% endfor %}
-                </div>
-
-                <div class="form-group">
-                    <a href="{{ path('lexik_translation_grid') }}" class="btn btn-default">
-                        <span class="glyphicon glyphicon-arrow-left"></span>
-                        {{ 'translations.back_to_list'|trans({}, 'LexikTranslationBundle') }}
-                    </a>
-
-                    <div class="btn-group pull-right">
-                        {{ form_widget(form.save, { 'attr': {'id': 'trans-unit-submit', 'name': 'trans-unit-submit', 'class': 'btn btn-primary'} }) }}
-                        {{ form_widget(form.save_add, { 'attr': {'id': 'trans-unit-submit-2', 'name': 'trans-unit-submit-2', 'class': 'btn btn-primary'} }) }}
-                    </div>
-                </div>
-
-                {{ form_end(form) }}
-
+            <div class="form-group">
+                {{ form_label(form.domain) }}
+                {{ form_widget(form.domain, { 'attr': {'class': 'form-control'} }) }}
+                <span class="text-danger">{{ form_errors(form.domain) }}</span>
             </div>
+
+            <div class="form-group">
+                {{ form_label(form.translations) }}
+            </div>
+
+            <div class="form-group">
+                {% for translation in form.translations %}
+                    {{ form_label(translation) }}
+                    {{ form_widget(translation.content, { 'attr': {'class': 'form-control'} }) }}
+                    <span class="text-danger">{{ form_errors(translation.content) }}</span>
+                    {{ form_widget(translation.locale) }}
+                {% endfor %}
+            </div>
+
+            <div class="form-group">
+                <a href="{{ path('lexik_translation_grid') }}" class="btn btn-default">
+                    <span class="glyphicon glyphicon-arrow-left"></span>
+                    {{ 'translations.back_to_list'|trans({}, 'LexikTranslationBundle') }}
+                </a>
+
+                <div class="btn-group pull-right">
+                    {{ form_widget(form.save, { 'attr': {'id': 'trans-unit-submit', 'name': 'trans-unit-submit', 'class': 'btn btn-primary'} }) }}
+                    {{ form_widget(form.save_add, { 'attr': {'id': 'trans-unit-submit-2', 'name': 'trans-unit-submit-2', 'class': 'btn btn-primary'} }) }}
+                </div>
+            </div>
+
+            {{ form_end(form) }}
+
         </div>
     </div>
 {% endblock %}

--- a/Resources/views/Translation/overview.html.twig
+++ b/Resources/views/Translation/overview.html.twig
@@ -10,72 +10,70 @@
 {% block lexik_title %}{{ 'overview.page_title'|trans }}{% endblock %}
 
 {% block lexik_content %}
-    <div class="container">
-        {% block lexik_toolbar %}
-            <div class="page-header">
-                <h1>
-                    {{ 'overview.page_title'|trans }}
-                    <div class="pull-right">
-                        <a href="{{ path('lexik_translation_grid') }}" role="button" class="btn btn-primary">
-                            <span class="glyphicon glyphicon-th"></span>
-                            {{ 'overview.show_grid'|trans }}
-                        </a>
-                    </div>
-                </h1>
-            </div>
-        {% endblock lexik_toolbar %}
-
-        <p>{{ 'overview.msg_latest_translation'|trans({'%date%': latestTrans|date('Y-m-d H:i')}) }}</p>
-
-        <div id="translation-overview">
-            <div class="row margin-row">
-                <div class="col-md-12">
-                    {% if  not stats|length %}
-                        <div class="alert alert-info">{{ 'overview.no_stats'|trans }}</div>
-                    {% else %}
-                        <table class="table table-bordered table-striped table-overview">
-                            <thead>
-                                <tr>
-                                    <th class="sortable col-0">
-                                        {{ 'overview.domain'|trans }}
-                                    </th>
-                                    {% for locale in locales %}
-                                        <th class="sortable col-{{ loop.index }}">
-                                            {{ locale|upper }}
-                                        </th>
-                                    {% endfor %}
-                                </tr>
-                            </thead>
-                            <tbody>
-                            {% for domain in domains %}
-                                <tr columns="columns">
-                                    <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain }}">{{ domain }}</a></td>
-                                    {% for locale in locales %}
-                                        <td class="text-center">
-                                            <span class="text {{ stats[domain][locale]['completed'] == 100 ? 'text-success' : 'text-danger' }}">
-                                                {{ stats[domain][locale]['translated'] }} / {{ stats[domain][locale]['keys']|default(0) }}
-                                            </span>
-                                            <div class="progress">
-                                                <div class="progress-bar {{ stats[domain][locale]['completed'] == 100 ? 'progress-bar-success' : 'progress-bar-danger' }}"
-                                                     role="progressbar"
-                                                     aria-valuenow="{{ stats[domain][locale]['completed'] }}"
-                                                     aria-valuemin="0"
-                                                     aria-valuemax="100"
-                                                     style="width: {{ stats[domain][locale]['completed'] }}%">
-                                                </div>
-                                            </div>
-                                        </td>
-                                    {% endfor %}
-                                </tr>
-                            {% endfor %}
-                            </tbody>
-                        </table>
-                    {% endif %}
+    {% block lexik_toolbar %}
+        <div class="page-header">
+            <h1>
+                {{ 'overview.page_title'|trans }}
+                <div class="pull-right">
+                    <a href="{{ path('lexik_translation_grid') }}" role="button" class="btn btn-primary">
+                        <span class="glyphicon glyphicon-th"></span>
+                        {{ 'overview.show_grid'|trans }}
+                    </a>
                 </div>
+            </h1>
+        </div>
+    {% endblock lexik_toolbar %}
+
+    <p>{{ 'overview.msg_latest_translation'|trans({'%date%': latestTrans|date('Y-m-d H:i')}) }}</p>
+
+    <div id="translation-overview">
+        <div class="row margin-row">
+            <div class="col-md-12">
+                {% if  not stats|length %}
+                    <div class="alert alert-info">{{ 'overview.no_stats'|trans }}</div>
+                {% else %}
+                    <table class="table table-bordered table-striped table-overview">
+                        <thead>
+                            <tr>
+                                <th class="sortable col-0">
+                                    {{ 'overview.domain'|trans }}
+                                </th>
+                                {% for locale in locales %}
+                                    <th class="sortable col-{{ loop.index }}">
+                                        {{ locale|upper }}
+                                    </th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for domain in domains %}
+                            <tr columns="columns">
+                                <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain }}">{{ domain }}</a></td>
+                                {% for locale in locales %}
+                                    <td class="text-center">
+                                        <span class="text {{ stats[domain][locale]['completed'] == 100 ? 'text-success' : 'text-danger' }}">
+                                            {{ stats[domain][locale]['translated'] }} / {{ stats[domain][locale]['keys']|default(0) }}
+                                        </span>
+                                        <div class="progress">
+                                            <div class="progress-bar {{ stats[domain][locale]['completed'] == 100 ? 'progress-bar-success' : 'progress-bar-danger' }}"
+                                                 role="progressbar"
+                                                 aria-valuenow="{{ stats[domain][locale]['completed'] }}"
+                                                 aria-valuemin="0"
+                                                 aria-valuemax="100"
+                                                 style="width: {{ stats[domain][locale]['completed'] }}%">
+                                            </div>
+                                        </div>
+                                    </td>
+                                {% endfor %}
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
             </div>
         </div>
-
     </div>
+
 {% endblock %}
 
 {% block lexik_javascript_footer %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -26,7 +26,9 @@
             </div>
         {% endblock lexik_flash_message %}
 
-        {% block lexik_content '' %}
+        <div class="container">
+            {% block lexik_content '' %}
+        </div>
 
         {% block lexik_javascript_footer %}
             <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>


### PR DESCRIPTION
Moved the container class (bootstrap) into the layout template. It makes more sense for two reasons:
1. Code optimization: As the 3 templates extending the layout (overview, new and grid) are adding this class, it is optimized to put it only on the layout template.
2. For a better integration with backends, where there often is a sidebar on the left, the container class breaks near the breakpoints, and so we can more easily fix it by replacing this class by a container-fluid class by example.

Most of the changes are indents.