### PR TITLE
 #306. set public of 'translate' alias for compatibility with other components in SF4.

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -233,7 +233,11 @@ class LexikTranslationExtension extends Extension
     protected function registerTranslatorConfiguration(array $config, ContainerBuilder $container)
     {
         // use the Lexik translator as default translator service
-        $container->setAlias('translator', 'lexik_translation.translator');
+        $alias = $container->setAlias('translator', 'lexik_translation.translator');
+
+        if (Kernel::VERSION_ID >= 30400) {
+            $alias->setPublic(true);
+        }
 
         $translator = $container->findDefinition('lexik_translation.translator');
         $translator->addMethodCall('setFallbackLocales', array($config['fallback_locale']));

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,6 +46,7 @@
         <parameter key="lexik_translation.token_finder.class">Lexik\Bundle\TranslationBundle\Util\Profiler\TokenFinder</parameter>
 
         <parameter key="lexik_translation.command.import_translations.class">Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand</parameter>
+        <parameter key="lexik_translation.command.export_translations.class">Lexik\Bundle\TranslationBundle\Command\ExportTranslationsCommand</parameter>
 
         <parameter key="lexik_translation.importer.case_insensitive">false</parameter>
         <parameter key="lexik_translation.token_finder.limit">15</parameter>
@@ -152,10 +153,16 @@
             <tag name="kernel.event_listener" event="lexik_translation.event.get_database_resources" method="onGetDatabaseResources"  />
         </service>
 
+
         <!-- Command -->
-        <service id="Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand" class="%lexik_translation.command.import_translations.class%" autowire="true">
-            <argument type="service" id="lexik_translation.translator" />
+        <service id="Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand" class="%lexik_translation.command.import_translations.class%">
+            <argument type="service" id="translator" />
             <tag name="console.command" />
         </service>
+
+        <service id="Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand" class="%lexik_translation.command.export_translations.class%">
+            <tag name="console.command" />
+        </service>
+        
     </services>
 </container>

--- a/Tests/Command/ImportTranslationsCommandTest.php
+++ b/Tests/Command/ImportTranslationsCommandTest.php
@@ -79,7 +79,7 @@ class ImportTranslationsCommandTest extends WebTestCase
      */
     public function testExecute()
     {
-        static::$application->add(new ImportTranslationsCommand(self::$kernel->getContainer()->get('lexik_translation.translator')));
+        static::$application->add(new ImportTranslationsCommand(self::$kernel->getContainer()->get('translator')));
 
         $command = static::$application->find("lexik:translations:import");
         $command->setContainer(static::$kernel->getContainer());


### PR DESCRIPTION
Translator should be public, they can be use on other bundles.
Also 'translator' has in list like public service: https://github.com/symfony/symfony/pull/24104