### PR TITLE
Corrected ExportTranslationsCommand service id.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -160,7 +160,7 @@
             <tag name="console.command" />
         </service>
 
-        <service id="Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand" class="%lexik_translation.command.export_translations.class%">
+        <service id="Lexik\Bundle\TranslationBundle\Command\ExportTranslationsCommand" class="%lexik_translation.command.export_translations.class%">
             <tag name="console.command" />
         </service>
         


### PR DESCRIPTION
This is probably a simple overlook.