### PR TITLE
Prevent returning all results when search string is not found

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -219,9 +219,7 @@ class TransUnitRepository extends EntityRepository
 
             $ids = $qb->getQuery()->getResult('SingleColumnArrayHydrator');
 
-            if (count($ids) > 0) {
-                $builder->andWhere($builder->expr()->in('tu.id', $ids));
-            }
+            $builder->andWhere($builder->expr()->in('tu.id', count($ids) > 0 ? $ids : [0]));
         }
     }
 


### PR DESCRIPTION
Now when search keyword is not found all results are returned, which is bad behavior.
Fixed to return no results. 