### PR TITLE
Fix BC with Symfony 2.8 LTS

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -141,7 +141,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
         $rootDir = 'vendor/lexik/translation-bundle/Resources/views';
 
         // Only symfony versions >= 3.3 include the kernel.project_dir parameter
-        if ($container->hasParameter('kernel.project_dir')) {
+        if (Kernel::VERSION_ID >= 30300) {
             $rootDir = '%kernel.project_dir%/'.$rootDir;
         } else {
             $rootDir = '%kernel.root_dir%/../'.$rootDir;

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -138,9 +138,18 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
             return;
         }
 
+        $rootDir = 'vendor/lexik/translation-bundle/Resources/views';
+
+        // Only symfony versions >= 3.3 include the kernel.project_dir parameter
+        if ($container->hasParameter('kernel.project_dir')) {
+            $rootDir = '%kernel.project_dir%/'.$rootDir;
+        } else {
+            $rootDir = '%kernel.root_dir%/../'.$rootDir;
+        }
+
         $container->prependExtensionConfig('twig', [
             'paths' => [
-                '%kernel.project_dir%/vendor/lexik/translation-bundle/Resources/views' => 'LexikTranslationBundle'
+                $rootDir => 'LexikTranslationBundle'
             ]
         ]);
     }


### PR DESCRIPTION
The parameter `%kernel.project_dir%` is not existent in symfony versions prior to version 3.3. This fix checks whether the parameter `%kernel.project_dir%` exists, otherwise it will use the `%kernel.root_dir%/../` as an alternative.

Fixes #321 