### PR TITLE
Import with '--merge' option doesn't update existing translations

### DIFF
--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -128,6 +128,7 @@ class TransUnitManager implements TransUnitManagerInterface
         if ($found) {
             /* @var Translation $translation */
             $translation = $transUnit->getTranslations()->get($i - 1);
+
             if ($merge) {
                 if ($translation->isModifiedManually() || $translation->getContent() == $content) {
                     return null;
@@ -138,11 +139,13 @@ class TransUnitManager implements TransUnitManagerInterface
                 $this->storage->flush();
 
                 $newTranslation->setContent($content);
+                $transUnit->addTranslation($newTranslation);
+
                 $this->storage->persist($newTranslation);
                 $translation = $newTranslation;
+            } else {
+                $translation->setContent($content);
             }
-
-            $translation->setContent($content);
         }
 
         if (null !== $translation && $this->storage instanceof PropelStorage) {

--- a/Resources/config/doctrine/TransUnit.mongodb.xml
+++ b/Resources/config/doctrine/TransUnit.mongodb.xml
@@ -15,7 +15,7 @@
 
         <field fieldName="id" name="id" id="true" strategy="AUTO" />
 
-        <embed-many field="translations" target-document="Lexik\Bundle\TranslationBundle\Document\Translation" strategy="set" />
+        <embed-many field="translations" target-document="Lexik\Bundle\TranslationBundle\Document\Translation" strategy="setArray" />
 
     </document>
 </doctrine-mongo-mapping>

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -123,21 +123,22 @@ class FileImporter
                 $transUnit = $this->transUnitManager->create($key, $domain);
             }
 
-                $translation = $this->transUnitManager->addTranslation($transUnit, $locale, $content, $translationFile);
+            $translation = $this->transUnitManager->addTranslation($transUnit, $locale, $content, $translationFile);
+
+            if ($translation instanceof TranslationInterface) {
+                $imported++;
+            } else if($forceUpdate) {
+                $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content);
+                if ($translation instanceof Translation) {
+                    $translation->setModifiedManually(false);
+                }
+                $imported++;
+            } else if($merge) {
+                $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content, false, true);
                 if ($translation instanceof TranslationInterface) {
                     $imported++;
-                } else if($forceUpdate) {
-                    $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content);
-                    if ($translation instanceof Translation) {
-                        $translation->setModifiedManually(false);
-                    }
-                    $imported++;
-                } else if($merge) {
-                    $translation = $this->transUnitManager->updateTranslation($transUnit, $locale, $content, false, true);
-                    if ($translation instanceof TranslationInterface) {
-                        $imported++;
-                    }
                 }
+            }
 
             $keys[] = $normalizedKey;
 


### PR DESCRIPTION
When using import command with --merge option, updated translations aren't actually updated, but removed instead (appears when using ODM, not sure if behaves differently with ORM).

In import code the translation is removed from DB before it is cloned for (kinda) update, effectively removing original trans record reference from TransUnit record. Cloned translation record after that is persisted into DB, but there are no reference from TransUnit to newly created Translation record at that moment.

ext-mongo: 1.6.16
ext-mongodb: ^1.4
doctrine/mongodb-odm-bundle: ^3.3