### PR TITLE
Use correct new symfony 4 translations directory

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -310,6 +310,10 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
                 $dirs[] = $dir;
             }
 
+            if (Kernel::MAJOR_VERSION >= 4 && is_dir($dir = $container->getParameter('kernel.project_dir').'/translations')) {
+                $dirs[] = $dir;
+            }
+
             // Register translation resources
             if (count($dirs) > 0) {
                 foreach ($dirs as $dir) {


### PR DESCRIPTION
Since Symfony 4, a new directory structured is been used. 

With this commit, the new translations directory in the project root dir will also be included in the directories where the bundle will look for translations. All translations files under the 'translations' directory will be included.