### PR TITLE
Sf4 fix

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -199,7 +199,12 @@ class ImportTranslationsCommand extends ContainerAwareCommand
      */
     protected function importAppTranslationFiles(array $locales, array $domains)
     {
-        $finder = $this->findTranslationsFiles($this->getApplication()->getKernel()->getRootDir(), $locales, $domains);
+        if (Kernel::MAJOR_VERSION >= 4) {
+            $translationPath = $this->getApplication()->getKernel()->getProjectDir().'/translations';
+            $finder = $this->findTranslationsFiles($translationPath, $locales, $domains, false);
+        } else {
+            $finder = $this->findTranslationsFiles($this->getApplication()->getKernel()->getRootDir(), $locales, $domains);
+        }
         $this->importTranslationFiles($finder);
     }
 

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -310,6 +310,10 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
                 $dirs[] = $dir;
             }
 
+            if (Kernel::MAJOR_VERSION >= 4 && is_dir($dir = $container->getParameter('kernel.project_dir').'/translations')) {
+                $dirs[] = $dir;
+            }
+
             // Register translation resources
             if (count($dirs) > 0) {
                 foreach ($dirs as $dir) {

--- a/EventDispatcher/CleanTranslationCacheListener.php
+++ b/EventDispatcher/CleanTranslationCacheListener.php
@@ -65,6 +65,8 @@ class CleanTranslationCacheListener
             $lastUpdateTime = $this->storage->getLatestUpdatedAt();
 
             if ($lastUpdateTime instanceof \DateTime) {
+                $this->checkCacheFolder();
+
                 $finder = new Finder();
                 $finder->files()
                     ->in($this->cacheDirectory.'/translations')
@@ -108,5 +110,12 @@ class CleanTranslationCacheListener
         }
 
         return $expired;
+    }
+
+    private function checkCacheFolder()
+    {
+        if (!is_dir($dirName = $this->cacheDirectory.'/translations') && !mkdir($dirName) && !is_dir($dirName)) {
+            throw new \RuntimeException(sprintf('Directory "%s" was not created', $dirName));
+        }
     }
 }


### PR DESCRIPTION
Since Symfony 4, a new directory structured is been used.

With this commit, the new translations directory in the project root dir will also be included in the directories where the bundle will look for translations. All translations files under the 'translations' directory will be included.