### PR TITLE
Add Symfony 4.3 kernel.locale_aware tag

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -105,6 +105,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
 
         $translator->setArguments($arguments);
         $translator->addMethodCall('setConfigCacheFactory', [new Reference('config_cache_factory')]);
+        $translator->addTag('kernel.locale_aware');
 
         $container->setDefinition('lexik_translation.translator', $translator);
     }


### PR DESCRIPTION
Symfony 4.3 does not use the TranslatorListener anymore to set the locale. Instead, the LocaleAwareListener is used to collect locale aware services and set the locale on them. This tag makes sure the Lexik translator is marked as a locale aware service so the locale is set correctly in Symfony >= 4.3 without breaking compatibility with earlier versions.