### PR TITLE
Fix translator dirs by relying on `translator.default_path` #333

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -199,8 +199,9 @@ class ImportTranslationsCommand extends ContainerAwareCommand
      */
     protected function importAppTranslationFiles(array $locales, array $domains)
     {
-        if (Kernel::MAJOR_VERSION >= 4) {
-            $translationPath = $this->getApplication()->getKernel()->getProjectDir().'/translations';
+        if ($this->getContainer()->hasParameter('translator.default_path')
+            && is_dir($translationPath = $this->getContainer()->getParameter('translator.default_path'))
+        ) {
             $finder = $this->findTranslationsFiles($translationPath, $locales, $domains, false);
         } else {
             $finder = $this->findTranslationsFiles($this->getApplication()->getKernel()->getRootDir(), $locales, $domains);

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -311,7 +311,9 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
                 $dirs[] = $dir;
             }
 
-            if (Kernel::MAJOR_VERSION >= 4 && is_dir($dir = $container->getParameter('kernel.project_dir').'/translations')) {
+            if ($container->hasParameter('translator.default_path')
+                && is_dir($dir = $container->getParameter('translator.default_path'))
+            ) {
                 $dirs[] = $dir;
             }
 


### PR DESCRIPTION
Fix #333 

Rely on `translator.default_path` added since 3.4.0 instead of `Kernel::MAJOR_VERSION`