### PR TITLE
Fix deprecation in Symfony 4.4.

### DIFF
--- a/Command/ExportTranslationsCommand.php
+++ b/Command/ExportTranslationsCommand.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,7 +14,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class ExportTranslationsCommand extends ContainerAwareCommand
+class ExportTranslationsCommand extends Command
 {
     /**
      * @var \Symfony\Component\Console\Input\InputInterface

--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
  * @author Cédric Girard <c.girard@lexik.fr>
  * @author Nikola Petkanski <nikola@petkanski.com>
  */
-class ImportTranslationsCommand extends ContainerAwareCommand
+class ImportTranslationsCommand extends Command
 {
     /**
      * @var \Symfony\Component\Console\Input\InputInterface


### PR DESCRIPTION
## Description

Fixes deprecation in Symfony 4.4.

`The 'Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand' class is deprecated since Symfony 4.2, use 'Symfony\Component\Console\Command\Command' with dependency injection instead.`

This will allow projects using the LexikTranslationBundle to upgrade to Symfony 5.