### PR TITLE
Escape domain name in URL

### DIFF
--- a/Resources/views/Translation/overview.html.twig
+++ b/Resources/views/Translation/overview.html.twig
@@ -49,7 +49,7 @@
                             <tbody>
                             {% for domain in domains %}
                                 <tr columns="columns">
-                                    <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain }}">{{ domain }}</a></td>
+                                    <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain|e('url') }}">{{ domain }}</a></td>
                                     {% for locale in locales %}
                                         <td class="text-center">
                                             <span class="text {{ stats[domain][locale]['completed'] == 100 ? 'text-success' : 'text-danger' }}">


### PR DESCRIPTION
I noticed that unescaped domain name may cause issues sometimes.

To be more concrete, I have my translations in messages+intl-icu.LANG.yaml file, but when I click on that file in the list, no results (translation strings) are shown, because what ends up in the domain filter box is actually not "messages+intl-icu", but "messages intl-icu". This little patch fixes that issue.

Note: I think presenting "messages" and "messages+intl-icu" as separate domains is the actual problem, which this patch does not address. I just wanted to pick the lowest hanging fruit and be done with it for now.