### PR TITLE
fix tree builder pass root node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('lexik_translation');
+        $treeBuilder = new TreeBuilder('lexik_translation');
+        $rootNode = $treeBuilder->getRootNode();
 
         $storages = array(
             StorageInterface::STORAGE_ORM,


### PR DESCRIPTION
not passing the root node is deprecated in symfony 4.3
and doesn't seem to work anymore in symfony 4.4.

https://symfony.com/doc/4.4/components/config/definition.html#defining-a-hierarchy-of-configuration-values-using-the-treebuilder