### PR TITLE
Added mysql service for travis and only build for Symfony 4.0 for now…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,14 @@ language: php
 sudo: false
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
+    - 8.0
 
 matrix:
     fast_finish: true
-    exclude:
-    - php: 5.6
-      env: SYMFONY_VERSION=4.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.0
-      env: SYMFONY_VERSION=4.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=2.8.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=3.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=3.1.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=3.2.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=3.3.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - php: 7.2
-      env: SYMFONY_VERSION=3.4.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
 
 services:
     - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
 
 env:
     - SYMFONY_VERSION=4.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
+    - SYMFONY_VERSION=4.4.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
 cache:
     directories:
         - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4
-    - 8.0
+#    - 7.4 # needs new version of PHPUnit because of deprecations in reflection when building mock objects
+#    - 8.0 # need to specify php version differently in composer.json ^7.1 does not allow 8
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,9 @@ matrix:
 
 services:
     - mongodb
+    - mysql
 
 env:
-    - SYMFONY_VERSION=2.8.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - SYMFONY_VERSION=3.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - SYMFONY_VERSION=3.1.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - SYMFONY_VERSION=3.2.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - SYMFONY_VERSION=3.3.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
-    - SYMFONY_VERSION=3.4.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
     - SYMFONY_VERSION=4.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ php:
     - 7.1
     - 7.2
     - 7.3
-#    - 7.4 # needs new version of PHPUnit because of deprecations in reflection when building mock objects
-#    - 8.0 # need to specify php version differently in composer.json ^7.1 does not allow 8
+    - 7.4
+#    - 8.0  PHP 7.1 requires a version of PHPUnit (7.5.2) that is too old for 8.0
 
 matrix:
     fast_finish: true

--- a/Tests/Unit/BaseUnitTestCase.php
+++ b/Tests/Unit/BaseUnitTestCase.php
@@ -240,7 +240,8 @@ abstract class BaseUnitTestCase extends TestCase
         $config->setDefaultCommitOptions(array());
 
         $options = array();
-        $conn = new \Doctrine\MongoDB\Connection(null, $options, $config);
+        $server = getenv('MONGO_SERVER') ?: null;
+        $conn = new \Doctrine\MongoDB\Connection($server, $options, $config, null, ['']);
 
         $dm = \Doctrine\ODM\MongoDB\DocumentManager::create($conn, $config);
 

--- a/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
@@ -102,8 +102,8 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
                 array('locale' => 'fr', 'content' => 'au revoir'),
             )),
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'de', 'content' => 'heil'),
                 array('locale' => 'fr', 'content' => 'salut'),
+                array('locale' => 'de', 'content' => 'heil'),
             )),
             array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
                 array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
@@ -133,8 +133,8 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'en'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'fr' => 'alu'));
         $expected = array(
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'en', 'content' => 'hello'),
                 array('locale' => 'fr', 'content' => 'salut'),
+                array('locale' => 'en', 'content' => 'hello'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);
@@ -142,12 +142,12 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 1, array('sidx' => 'domain', 'sord' => 'ASC'));
         $expected = array(
             array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'en', 'content' => 'goodbye'),
                 array('locale' => 'fr', 'content' => 'au revoir'),
+                array('locale' => 'en', 'content' => 'goodbye'),
             )),
             array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'en', 'content' => 'what the fuck !?!'),
                 array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
+                array('locale' => 'en', 'content' => 'what the fuck !?!'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);
@@ -155,9 +155,9 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 2, array('sidx' => 'domain', 'sord' => 'ASC'));
         $expected = array(
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'de', 'content' => 'heil'),
-                array('locale' => 'en', 'content' => 'hello'),
                 array('locale' => 'fr', 'content' => 'salut'),
+                array('locale' => 'en', 'content' => 'hello'),
+                array('locale' => 'de', 'content' => 'heil'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);

--- a/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
@@ -226,13 +226,12 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
             $translationsByLocale = [];
 
             foreach ($result[$i]['translations'] as $row) {
-                $locale = $row['locale'];
-                $translationsByLocale[$locale] = $row;
+                $translationsByLocale[$row['locale']] = $row;
             }
 
             foreach ($transUnit['translations'] as $j => $translation) {
-                $locale1 = $translation['locale'];
-                $this->assertEquals($translation['content'], $translationsByLocale[$locale1]['content']);
+                $locale = $translation['locale'];
+                $this->assertEquals($translation['content'], $translationsByLocale[$locale]['content']);
             }
         }
     }

--- a/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
@@ -217,9 +217,22 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
 
             $this->assertEquals(count($transUnit['translations']), count($result[$i]['translations']));
 
+            /*
+             * $expected has a fixed order. It is unsafe to rely on the order in which
+             * items are returned from the database. Therefore, the results from the database
+             * must be indexed by locale, before making any assertions, otherwise, random false negatives
+             * will occur.
+             */
+            $translationsByLocale = [];
+
+            foreach ($result[$i]['translations'] as $row) {
+                $locale = $row['locale'];
+                $translationsByLocale[$locale] = $row;
+            }
+
             foreach ($transUnit['translations'] as $j => $translation) {
-                $this->assertEquals($translation['locale'], $result[$i]['translations'][$j]['locale']);
-                $this->assertEquals($translation['content'], $result[$i]['translations'][$j]['content']);
+                $locale1 = $translation['locale'];
+                $this->assertEquals($translation['content'], $translationsByLocale[$locale1]['content']);
             }
         }
     }

--- a/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
@@ -102,8 +102,8 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
                 array('locale' => 'fr', 'content' => 'au revoir'),
             )),
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'salut'),
                 array('locale' => 'de', 'content' => 'heil'),
+                array('locale' => 'fr', 'content' => 'salut'),
             )),
             array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
                 array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
@@ -133,8 +133,8 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'en'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'fr' => 'alu'));
         $expected = array(
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'salut'),
                 array('locale' => 'en', 'content' => 'hello'),
+                array('locale' => 'fr', 'content' => 'salut'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);
@@ -142,12 +142,12 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 1, array('sidx' => 'domain', 'sord' => 'ASC'));
         $expected = array(
             array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'au revoir'),
                 array('locale' => 'en', 'content' => 'goodbye'),
+                array('locale' => 'fr', 'content' => 'au revoir'),
             )),
             array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
                 array('locale' => 'en', 'content' => 'what the fuck !?!'),
+                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);
@@ -155,9 +155,9 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 2, array('sidx' => 'domain', 'sord' => 'ASC'));
         $expected = array(
             array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'salut'),
-                array('locale' => 'en', 'content' => 'hello'),
                 array('locale' => 'de', 'content' => 'heil'),
+                array('locale' => 'en', 'content' => 'hello'),
+                array('locale' => 'fr', 'content' => 'salut'),
             )),
         );
         $this->assertSameTransUnit($expected, $result);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "lexik/translation-bundle",
     "type": "symfony-bundle",
     "description": "This bundle allows to import translation files content into the database and provide a GUI to edit translations.",
-    "keywords": ["Symfony2", "bundle", "translation", "i18n"],
+    "keywords": ["Symfony", "bundle", "translation", "i18n"],
     "homepage": "https://github.com/lexik/LexikTranslationBundle",
     "license": "MIT",
     "prefer-stable": true,
@@ -17,21 +17,20 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0"
+        "php": "^7.1",
+        "symfony/symfony": "~4.4"
     },
     "require-dev": {
-        "doctrine/orm": "^2.2.3",
+        "alcaeus/mongo-php-adapter": "~1.0",
+        "doctrine/orm": ">=2.4",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/data-fixtures": "~1.1",
         "doctrine/mongodb-odm-bundle": "~3.0",
-        "propel/propel-bundle": "^3.0@dev|^4.0@dev",
-        "propel/propel": "@dev",
+        "propel/propel": "2.0.0-alpha10|dev-master",
         "phpunit/phpunit": "^5.7"
     },
     "suggest": {
-        "doctrine/orm": ">=2.4",
-        "doctrine/mongodb-odm-bundle": "~3.0"
+        "doctrine/orm": ">=2.4"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\TranslationBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/data-fixtures": "~1.1",
         "doctrine/mongodb-odm-bundle": "~3.0",
         "propel/propel": "2.0.0-alpha10|dev-master",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "~7.5.2"
     },
     "suggest": {
         "doctrine/orm": ">=2.4"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="Tests/bootstrap.php"
         >
     <testsuites>


### PR DESCRIPTION
Should add 5 when deprecation warnings have been taken care of.

This PR is basically a try-out to see if adding the mysql service to the travis config will fix the tests on master. If so, it may be merged. 

It only builds for Symfony 4.0 for now.

I had to fix composer dependencies. 

I also had to fix a test that relies on a specific order in which items come back from the database, which might be a bad idea, but the code is ancient (2011), so it is strange it had to be changed. The translation were done fine in these test cases, just the order was different.

To be able to build for PHP 7.4 and 8.0, it is required that we update the unit tests and use a more compatible version of PHPUnit, preferably the latest. How are we with support for older version of php on master? We have the 3.4 branch for ancient versions, but how far back do we want to support PHP 7? I would have to investigate if we need another branch for symfony 4, so that we can leave older PHP 7 versions behind for Symfony 5.