### PR TITLE
Move symfony/symfony requirement to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/symfony": "~4.4"
+        "php": "^7.1"
     },
     "require-dev": {
+        "symfony/symfony": "~4.4",
         "alcaeus/mongo-php-adapter": "~1.0",
         "doctrine/orm": ">=2.4",
         "doctrine/doctrine-bundle": "~1.2",
@@ -28,9 +28,6 @@
         "doctrine/mongodb-odm-bundle": "~3.0",
         "propel/propel": "2.0.0-alpha10|dev-master",
         "phpunit/phpunit": "~7.5.2"
-    },
-    "suggest": {
-        "doctrine/orm": ">=2.4"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\TranslationBundle\\": "" }


### PR DESCRIPTION
Resolved issue with installation. Requirement of symfony/symfony should be in dev, because a Symfony 4.4 application cannot install symfony/symfony. This conflicts because it _is_ Symfony.

I confirmed in a fresh Symfony 4.4 app that the installation with composer now works, but the readme can be updated or maybe recipies can be improved to allow proper autoconfiguring. Now the initial installation fails, because configuration needs to be in place in order for cache:clear to work. 