### PR TITLE
symfony/symfony and mongo requirements moved to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^7.4",
-        "symfony/symfony": "~5.0",
-        "ext-mongodb": "*"
+        "php": "^7.4"
     },
     "require-dev": {
+        "symfony/symfony": "~5.0",
+        "ext-mongodb": "*",
         "doctrine/orm": ">=2.4",
         "doctrine/doctrine-bundle": "^2.2",
         "doctrine/data-fixtures": "~1.1",


### PR DESCRIPTION
To allow installation with composer, symfony/symfony should not be required, because it would conflict with a symfony application. Mongodb is not strictly a requirement, but it is required for development of this bundle, so it should go to require-dev.