### PR TITLE
Get rid of deprecation warinings in Symfony4.4

### DIFF
--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -3,14 +3,14 @@
 namespace Lexik\Bundle\TranslationBundle\Controller;
 
 use Lexik\Bundle\TranslationBundle\Util\Csrf\CsrfCheckerTrait;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class RestController extends Controller
+class RestController extends AbstractController
 {
     use CsrfCheckerTrait;
 
@@ -21,7 +21,7 @@ class RestController extends Controller
      */
     public function listAction(Request $request)
     {
-        list($transUnits, $count) = $this->get('lexik_translation.data_grid.request_handler')->getPage($request);
+        [$transUnits, $count] = $this->get('lexik_translation.data_grid.request_handler')->getPage($request);
 
         return $this->get('lexik_translation.data_grid.formatter')->createListResponse($transUnits, $count);
     }
@@ -34,7 +34,7 @@ class RestController extends Controller
      */
     public function listByProfileAction(Request $request, $token)
     {
-        list($transUnits, $count) = $this->get('lexik_translation.data_grid.request_handler')->getPageByToken($request, $token);
+        [$transUnits, $count] = $this->get('lexik_translation.data_grid.request_handler')->getPageByToken($request, $token);
 
         return $this->get('lexik_translation.data_grid.formatter')->createListResponse($transUnits, $count);
     }

--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -5,14 +5,14 @@ namespace Lexik\Bundle\TranslationBundle\Controller;
 use Lexik\Bundle\TranslationBundle\Form\Type\TransUnitType;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Util\Csrf\CsrfCheckerTrait;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class TranslationController extends Controller
+class TranslationController extends AbstractController
 {
     use CsrfCheckerTrait;
 

--- a/Resources/config/routing/api.yml
+++ b/Resources/config/routing/api.yml
@@ -1,24 +1,24 @@
 lexik_translation_list:
     path:     /translations
-    defaults: { _controller: "LexikTranslationBundle:Rest:list" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::listAction" }
     methods:  [GET]
 
 lexik_translation_profiler:
     path:     /translations/profiler/{token}
-    defaults: { _controller: "LexikTranslationBundle:Rest:listByProfile" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::listByProfileAction" }
     methods:  [GET]
 
 lexik_translation_update:
     path:     /translations/{id}
-    defaults: { _controller: "LexikTranslationBundle:Rest:update" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::updateAction" }
     methods:  [PUT]
 
 lexik_translation_delete_locale:
     path:     /translations/{id}/{locale}
-    defaults: { _controller: "LexikTranslationBundle:Rest:deleteTranslation" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::deleteTranslationAction" }
     methods:  [DELETE]
 
 lexik_translation_delete:
     path:     /translations/{id}
-    defaults: { _controller: "LexikTranslationBundle:Rest:delete" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::deleteAction" }
     methods:  [DELETE]

--- a/Resources/config/routing/app.yml
+++ b/Resources/config/routing/app.yml
@@ -1,19 +1,19 @@
 lexik_translation_overview:
     path:     /
-    defaults: { _controller: "LexikTranslationBundle:Translation:overview" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::overviewAction" }
     methods:  [GET]
 
 lexik_translation_grid:
     path:     /grid
-    defaults: { _controller: "LexikTranslationBundle:Translation:grid" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::gridAction" }
     methods:  [GET]
 
 lexik_translation_new:
     path:     /new
-    defaults: { _controller: "LexikTranslationBundle:Translation:new" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::newAction" }
     methods:  [GET, POST]
 
 lexik_translation_invalidate_cache:
     path:     /invalidate-cache
-    defaults: { _controller: "LexikTranslationBundle:Translation:invalidateCache" }
+    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::invalidateCacheAction" }
     methods:  [GET]


### PR DESCRIPTION
Controllers should extend AbstractController
Controllers should be configured by FQN and method name in routing config