### PR TITLE
Replace double quotes with single quotes in new route config

### DIFF
--- a/Resources/config/routing/api.yml
+++ b/Resources/config/routing/api.yml
@@ -1,24 +1,24 @@
 lexik_translation_list:
     path:     /translations
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::listAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\RestController::listAction' }
     methods:  [GET]
 
 lexik_translation_profiler:
     path:     /translations/profiler/{token}
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::listByProfileAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\RestController::listByProfileAction' }
     methods:  [GET]
 
 lexik_translation_update:
     path:     /translations/{id}
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::updateAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\RestController::updateAction' }
     methods:  [PUT]
 
 lexik_translation_delete_locale:
     path:     /translations/{id}/{locale}
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::deleteTranslationAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\RestController::deleteTranslationAction' }
     methods:  [DELETE]
 
 lexik_translation_delete:
     path:     /translations/{id}
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\RestController::deleteAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\RestController::deleteAction' }
     methods:  [DELETE]

--- a/Resources/config/routing/app.yml
+++ b/Resources/config/routing/app.yml
@@ -1,19 +1,19 @@
 lexik_translation_overview:
     path:     /
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::overviewAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\TranslationController::overviewAction' }
     methods:  [GET]
 
 lexik_translation_grid:
     path:     /grid
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::gridAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\TranslationController::gridAction' }
     methods:  [GET]
 
 lexik_translation_new:
     path:     /new
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::newAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\TranslationController::newAction' }
     methods:  [GET, POST]
 
 lexik_translation_invalidate_cache:
     path:     /invalidate-cache
-    defaults: { _controller: "Lexik\Bundle\TranslationBundle\Controller\TranslationController::invalidateCacheAction" }
+    defaults: { _controller: 'Lexik\Bundle\TranslationBundle\Controller\TranslationController::invalidateCacheAction' }
     methods:  [GET]


### PR DESCRIPTION
Replace double quotes with single quotes, otherwise the \ is seen asescape character and the routes won't work.