### PR TITLE
Fix domains for +intl-icu files

### DIFF
--- a/Resources/views/Translation/overview.html.twig
+++ b/Resources/views/Translation/overview.html.twig
@@ -49,7 +49,7 @@
                             <tbody>
                             {% for domain in domains %}
                                 <tr columns="columns">
-                                    <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain }}">{{ domain }}</a></td>
+                                    <td><a href="{{ path('lexik_translation_grid') }}#?filter[_domain]={{ domain | url_encode }}">{{ domain }}</a></td>
                                     {% for locale in locales %}
                                         <td class="text-center">
                                             <span class="text {{ stats[domain][locale]['completed'] == 100 ? 'text-success' : 'text-danger' }}">


### PR DESCRIPTION
![afbeelding](https://user-images.githubusercontent.com/37873948/107929743-5fddd980-6f7a-11eb-9a3a-df2bc71dd0c0.png)

Clicking on `messages+intl-icu` causes the + to be seen as a space, which then sets the wrong filter for the domain:

![afbeelding](https://user-images.githubusercontent.com/37873948/107929928-9e739400-6f7a-11eb-9312-ae5a87a4edc6.png)

| url_encode fixes this problem

![afbeelding](https://user-images.githubusercontent.com/37873948/107931087-1e4e2e00-6f7c-11eb-9607-35a40c5f9abf.png)
