### PR TITLE
Fix alias and overide

### DIFF
--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\TranslationBundle\Controller;
 
 use Lexik\Bundle\TranslationBundle\Form\Type\TransUnitType;
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Util\Csrf\CsrfCheckerTrait;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -115,6 +116,6 @@ class TranslationController extends AbstractController
      */
     protected function getManagedLocales()
     {
-        return $this->get('lexik_translation.locale.manager')->getLocales();
+        return $this->get(LocaleManagerInterface::class)->getLocales();
     }
 }

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\TranslationBundle\DependencyInjection;
 
 use Doctrine\ORM\Events;
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
@@ -122,7 +123,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
         $listener->addArgument(new Reference('lexik_translation.translation_storage'));
         $listener->addArgument(new Reference('translator'));
         $listener->addArgument(new Parameter('kernel.cache_dir'));
-        $listener->addArgument(new Reference('lexik_translation.locale.manager'));
+        $listener->addArgument(new Reference(LocaleManagerInterface::class));
         $listener->addArgument($cacheInterval);
 
         $listener->addTag('kernel.event_listener', array(
@@ -330,7 +331,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
 
                 foreach ($finder as $file) {
                     // filename is domain.locale.format
-                    list($domain, $locale, $format) = explode('.', $file->getBasename(), 3);
+                    [$domain, $locale, $format] = explode('.', $file->getBasename(), 3);
                     $translator->addMethodCall('addResource', array($format, (string) $file, $locale, $domain));
                 }
             }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -100,7 +100,7 @@
         <service id="Lexik\Bundle\TranslationBundle\Manager\LocaleManager" class="%lexik_translation.locale.manager.class%" public="true">
             <argument>%lexik_translation.managed_locales%</argument>
         </service>
-        <service id="lexik_translation.locale.manager" alias="Lexik\Bundle\TranslationBundle\Manager\LocaleManager" public="true" />
+        <service id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" alias="Lexik\Bundle\TranslationBundle\Manager\LocaleManager" public="true" />
 
         <!-- Importer -->
         <service id="Lexik\Bundle\TranslationBundle\Translation\Importer\FileImporter" class="%lexik_translation.importer.file.class%" >
@@ -141,7 +141,7 @@
 
         <!-- Data grid -->
         <service id="lexik_translation.data_grid.formatter" class="%lexik_translation.data_grid.formatter.class%" public="true">
-            <argument type="service" id="lexik_translation.locale.manager" />
+            <argument type="service" id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" />
             <argument>%lexik_translation.storage.type%</argument>
         </service>
 
@@ -149,7 +149,7 @@
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.file.manager" />
             <argument type="service" id="lexik_translation.translation_storage" />
-            <argument type="service" id="lexik_translation.locale.manager" />
+            <argument type="service" id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" />
             <call method="setCreateMissing">
                 <argument>%lexik_translation.dev_tools.create_missing%</argument>
             </call>
@@ -161,7 +161,7 @@
         <!-- Overview -->
         <service id="lexik_translation.overview.stats_aggregator" class="%lexik_translation.overview.stats_aggregator.class%" public="true">
             <argument type="service" id="lexik_translation.translation_storage" />
-            <argument type="service" id="lexik_translation.locale.manager" />
+            <argument type="service" id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" />
         </service>
 
         <!-- Form -->
@@ -169,7 +169,7 @@
             <argument type="service" id="lexik_translation.trans_unit.manager" />
             <argument type="service" id="lexik_translation.file.manager" />
             <argument type="service" id="lexik_translation.translation_storage" />
-            <argument type="service" id="lexik_translation.locale.manager" />
+            <argument type="service" id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" />
             <argument>%kernel.project_dir%</argument>
         </service>
 

--- a/Tests/Command/ImportTranslationsCommandTest.php
+++ b/Tests/Command/ImportTranslationsCommandTest.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\TranslationBundle\Tests\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DropSchemaDoctrineCommand;
+use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -81,7 +82,7 @@ class ImportTranslationsCommandTest extends WebTestCase
         static::$application->add(
             new ImportTranslationsCommand(
                 self::$kernel->getContainer()->get('translator'),
-                self::$kernel->getContainer()->get('lexik_translation.locale.manager'),
+                self::$kernel->getContainer()->get(LocaleManagerInterface::class),
                 self::$kernel->getContainer()->get('lexik_translation.importer.file')
             )
         );


### PR DESCRIPTION

Currently when we install lexik / LexikTranslationBundle.

```
Cannot autowire service "Lexik\Bundle\TranslationBundle\Command\ImportTrans  
!!    lationsCommand": argument "$localeManager" of method "__construct()" refere  
!!    nces interface "Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterfa  
!!    ce" but no such service exists. You should maybe alias this interface to th  
!!    e existing "Lexik\Bundle\TranslationBundle\Manager\LocaleManager" service. 
```

To correct the LocaleManager overload problem, you must:

- Keep the interface
- Rename `<service id="lexik_translation.locale.manager" alias="Lexik\Bundle\TranslationBundle\Manager\LocaleManager" public="true" />` to `<service id="Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface" alias="Lexik\Bundle\TranslationBundle\Manager\LocaleManager" public="true" />`
- Change all id service `lexik_translation.locale.manager` to `Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface`

Exemple for multiple implementations : [https://symfony.com/doc/5.4/service_container/autowiring.html#dealing-with-multiple-implementations-of-the-same-type](url)


After update with fix

<img width="717" alt="Capture d’écran 2021-12-02 à 13 44 38" src="https://user-images.githubusercontent.com/23743780/144424433-c27e5891-159b-4a94-bc63-afba63697240.png">

