### PR TITLE
Updated travis config, see if it will build for SF 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-    - 7.4
     - 8.0
 
 matrix:
@@ -14,7 +13,7 @@ services:
     - mysql
 
 env:
-    - SYMFONY_VERSION=5.2.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
+    - SYMFONY_VERSION=6.0.* DB=pdo_mysql DB_USER=root DB_NAME=lexik_test DEPENDENCIES=alpha
 cache:
     directories:
         - $HOME/.composer/cache


### PR DESCRIPTION
Let's see what Travis says when we build for Symfony 6 and PHP 8, which what master should be targetting today.