### PR TITLE
fix when no relation in record in trans_unit_translations and trans_unit table

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -24,6 +24,7 @@ class TransUnitRepository extends EntityRepository
         return $this->createQueryBuilder('tu')
             ->select('te.locale, tu.domain')
             ->leftJoin('tu.translations', 'te')
+            ->where('te.id is not null')
             ->addGroupBy('te.locale')
             ->addGroupBy('tu.domain')
             ->getQuery()


### PR DESCRIPTION
Fix when exist record (newest for some domain) in table trans_unit,  but there is no record in trans_unit_translations with same trans_unit_id. In this case method returned result where was locale = null, and it crash app.