### PR TITLE
Fixes that rector did for php 8.1

### DIFF
--- a/Controller/RestController.php
+++ b/Controller/RestController.php
@@ -18,59 +18,41 @@ class RestController extends AbstractController
 {
     use CsrfCheckerTrait;
 
-    private $dataGridRequestHandler;
-
-    private $dataGridFormatter;
-
-    private $translationStorage;
-
-    private $transUnitManager;
-
     private $csrfTokenManager;
 
     public function __construct(
-        DataGridRequestHandler $dataGridRequestHandler,
-        DataGridFormatter $dataGridFormatter,
-        StorageInterface $translationStorage,
-        TransUnitManagerInterface $transUnitManager
+        private readonly DataGridRequestHandler $dataGridRequestHandler,
+        private readonly DataGridFormatter $dataGridFormatter,
+        private readonly StorageInterface $translationStorage,
+        private readonly TransUnitManagerInterface $transUnitManager,
     ) {
-        $this->dataGridRequestHandler = $dataGridRequestHandler;
-        $this->dataGridFormatter = $dataGridFormatter;
-        $this->translationStorage = $translationStorage;
-        $this->transUnitManager = $transUnitManager;
     }
 
     /**
-     * @param Request $request
-     *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     public function listAction(Request $request)
     {
-        list($transUnits, $count) = $this->dataGridRequestHandler->getPage($request);
+        [$transUnits, $count] = $this->dataGridRequestHandler->getPage($request);
 
         return $this->dataGridFormatter->createListResponse($transUnits, $count);
     }
 
     /**
-     * @param Request $request
      * @param $token
-     *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     public function listByProfileAction(Request $request, $token)
     {
-        list($transUnits, $count) = $this->dataGridRequestHandler->getPageByToken($request, $token);
+        [$transUnits, $count] = $this->dataGridRequestHandler->getPageByToken($request, $token);
 
         return $this->dataGridFormatter->createListResponse($transUnits, $count);
     }
 
     /**
-     * @param Request $request
      * @param integer $id
      *
      * @return \Symfony\Component\HttpFoundation\JsonResponse
-     *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function updateAction(Request $request, $id)
@@ -101,7 +83,7 @@ class RestController extends AbstractController
 
         $deleted = $this->transUnitManager->delete($transUnit);
 
-        return new JsonResponse(array('deleted' => $deleted), $deleted ? 200 : 400);
+        return new JsonResponse(['deleted' => $deleted], $deleted ? 200 : 400);
     }
 
     /**
@@ -124,6 +106,6 @@ class RestController extends AbstractController
 
         $deleted = $this->transUnitManager->deleteTranslation($transUnit, $locale);
 
-        return new JsonResponse(array('deleted' => $deleted), $deleted ? 200 : 400);
+        return new JsonResponse(['deleted' => $deleted], $deleted ? 200 : 400);
     }
 }

--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -22,36 +22,8 @@ class TranslationController extends AbstractController
 {
     use CsrfCheckerTrait;
 
-    private $translationStorage;
-
-    private $statsAggregator;
-
-    private $tokenFinder;
-
-    private $transUnitFormHandler;
-
-    private $lexikTranslator;
-
-    private $translator;
-
-    private $localeManager;
-
-    public function __construct(
-        StorageInterface $translationStorage,
-        StatsAggregator $statsAggregator,
-        TransUnitFormHandler $transUnitFormHandler,
-        Translator $lexikTranslator,
-        TranslatorInterface $translator,
-        LocaleManagerInterface $localeManager,
-        ?TokenFinder $tokenFinder
-    ) {
-        $this->translationStorage = $translationStorage;
-        $this->statsAggregator = $statsAggregator;
-        $this->transUnitFormHandler = $transUnitFormHandler;
-        $this->lexikTranslator = $lexikTranslator;
-        $this->translator = $translator;
-        $this->localeManager = $localeManager;
-        $this->tokenFinder = $tokenFinder;
+    public function __construct(private readonly StorageInterface $translationStorage, private readonly StatsAggregator $statsAggregator, private readonly TransUnitFormHandler $transUnitFormHandler, private readonly Translator $lexikTranslator, private readonly TranslatorInterface $translator, private readonly LocaleManagerInterface $localeManager, private readonly ?\Lexik\Bundle\TranslationBundle\Util\Profiler\TokenFinder $tokenFinder)
+    {
     }
 
     /**
@@ -63,13 +35,7 @@ class TranslationController extends AbstractController
     {
         $stats = $this->statsAggregator->getStats();
 
-        return $this->render('@LexikTranslation/Translation/overview.html.twig', array(
-            'layout'         => $this->getParameter('lexik_translation.base_layout'),
-            'locales'        => $this->getManagedLocales(),
-            'domains'        => $this->translationStorage->getTransUnitDomains(),
-            'latestTrans'    => $this->translationStorage->getLatestUpdatedAt(),
-            'stats'          => $stats,
-        ));
+        return $this->render('@LexikTranslation/Translation/overview.html.twig', ['layout'         => $this->getParameter('lexik_translation.base_layout'), 'locales'        => $this->getManagedLocales(), 'domains'        => $this->translationStorage->getTransUnitDomains(), 'latestTrans'    => $this->translationStorage->getLatestUpdatedAt(), 'stats'          => $stats]);
     }
 
     /**
@@ -84,14 +50,7 @@ class TranslationController extends AbstractController
             $tokens = $this->tokenFinder->find();
         }
 
-        return $this->render('@LexikTranslation/Translation/grid.html.twig', array(
-            'layout'         => $this->getParameter('lexik_translation.base_layout'),
-            'inputType'      => $this->getParameter('lexik_translation.grid_input_type'),
-            'autoCacheClean' => $this->getParameter('lexik_translation.auto_cache_clean'),
-            'toggleSimilar'  => $this->getParameter('lexik_translation.grid_toggle_similar'),
-            'locales'        => $this->getManagedLocales(),
-            'tokens'         => $tokens,
-        ));
+        return $this->render('@LexikTranslation/Translation/grid.html.twig', ['layout'         => $this->getParameter('lexik_translation.base_layout'), 'inputType'      => $this->getParameter('lexik_translation.grid_input_type'), 'autoCacheClean' => $this->getParameter('lexik_translation.auto_cache_clean'), 'toggleSimilar'  => $this->getParameter('lexik_translation.grid_toggle_similar'), 'locales'        => $this->getManagedLocales(), 'tokens'         => $tokens]);
     }
 
     /**
@@ -103,12 +62,12 @@ class TranslationController extends AbstractController
     {
         $this->lexikTranslator->removeLocalesCacheFiles($this->getManagedLocales());
 
-        $message = $this->translator->trans('translations.cache_removed', array(), 'LexikTranslationBundle');
+        $message = $this->translator->trans('translations.cache_removed', [], 'LexikTranslationBundle');
 
         if ($request->isXmlHttpRequest()) {
             $this->checkCsrf();
 
-            return new JsonResponse(array('message' => $message));
+            return new JsonResponse(['message' => $message]);
         }
 
         $request->getSession()->getFlashBag()->add('success', $message);
@@ -126,7 +85,7 @@ class TranslationController extends AbstractController
         $form = $this->createForm(TransUnitType::class, $this->transUnitFormHandler->createFormData(), $this->transUnitFormHandler->getFormOptions());
 
         if ($this->transUnitFormHandler->process($form, $request)) {
-            $message = $this->translator->trans('translations.successfully_added', array(), 'LexikTranslationBundle');
+            $message = $this->translator->trans('translations.successfully_added', [], 'LexikTranslationBundle');
 
             $request->getSession()->getFlashBag()->add('success', $message);
 
@@ -135,10 +94,7 @@ class TranslationController extends AbstractController
             return $this->redirect($this->generateUrl($redirectUrl));
         }
 
-        return $this->render('@LexikTranslation/Translation/new.html.twig', array(
-            'layout' => $this->getParameter('lexik_translation.base_layout'),
-            'form'   => $form->createView(),
-        ));
+        return $this->render('@LexikTranslation/Translation/new.html.twig', ['layout' => $this->getParameter('lexik_translation.base_layout'), 'form'   => $form->createView()]);
     }
 
     /**

--- a/DependencyInjection/Compiler/RegisterMappingPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingPass.php
@@ -29,14 +29,14 @@ class RegisterMappingPass implements CompilerPassInterface
         if (StorageInterface::STORAGE_ORM == $storage['type'] && $container->hasDefinition($ormDriverId)) {
             $container->getDefinition($ormDriverId)->addMethodCall(
                 'addDriver',
-                array(new Reference('lexik_translation.orm.metadata.xml'), 'Lexik\Bundle\TranslationBundle\Model')
+                [new Reference('lexik_translation.orm.metadata.xml'), 'Lexik\Bundle\TranslationBundle\Model']
             );
         }
 
         if (StorageInterface::STORAGE_MONGODB == $storage['type'] && $container->hasDefinition($mongodbDriverId)) {
             $container->getDefinition($mongodbDriverId)->addMethodCall(
                 'addDriver',
-                array(new Reference('lexik_translation.mongodb.metadata.xml'), 'Lexik\Bundle\TranslationBundle\Model')
+                [new Reference('lexik_translation.mongodb.metadata.xml'), 'Lexik\Bundle\TranslationBundle\Model']
             );
         }
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,13 +24,13 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('lexik_translation');
         $rootNode = $treeBuilder->getRootNode();
 
-        $storages = array(
+        $storages = [
             StorageInterface::STORAGE_ORM,
             StorageInterface::STORAGE_MONGODB,
             StorageInterface::STORAGE_PROPEL,
-        );
-        $registrationTypes = array('all', 'files', 'database');
-        $inputTypes = array('text', 'textarea');
+        ];
+        $registrationTypes = ['all', 'files', 'database'];
+        $inputTypes = ['text', 'textarea'];
 
         $rootNode
             ->addDefaultsIfNotSet()
@@ -138,7 +138,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
 
             ->end()
-        ;
+            ->end();
 
         return $treeBuilder;
     }

--- a/Document/FileRepository.php
+++ b/Document/FileRepository.php
@@ -14,8 +14,6 @@ class FileRepository extends DocumentRepository
     /**
      * Returns all available domain/locale couples.
      *
-     * @param array $locales
-     * @param array $domains
      * @return array
      */
     public function findForLocalesAndDomains(array $locales, array $domains)
@@ -32,7 +30,7 @@ class FileRepository extends DocumentRepository
 
         $cursor = $builder->getQuery()->execute();
 
-        $files = array();
+        $files = [];
         foreach ($cursor as $result) {
             $files[] = $result;
         }

--- a/Document/TransUnitRepository.php
+++ b/Document/TransUnitRepository.php
@@ -106,9 +106,9 @@ class TransUnitRepository extends DocumentRepository
         }
 
         usort($domainsByLocale, function ($a, $b) {
-            $result = strcmp($a['locale'], $b['locale']);
+            $result = strcmp((string) $a['locale'], (string) $b['locale']);
             if (0 === $result) {
-                $result = strcmp($a['domain'], $b['domain']);
+                $result = strcmp((string) $a['domain'], (string) $b['domain']);
             }
             return $result;
         });
@@ -155,8 +155,8 @@ class TransUnitRepository extends DocumentRepository
      */
     public function getTransUnitList(array $locales = null, int $rows = 20, int $page = 1, array $filters = null): array
     {
-        $sortColumn = isset($filters['sidx']) ? $filters['sidx'] : 'id';
-        $order = isset($filters['sord']) ? $filters['sord'] : 'ASC';
+        $sortColumn = $filters['sidx'] ?? 'id';
+        $order = $filters['sord'] ?? 'ASC';
 
         $builder = $this->createQueryBuilder()
                         ->hydrate(false)
@@ -191,7 +191,7 @@ class TransUnitRepository extends DocumentRepository
                         ->execute();
 
         foreach ($results as $item) {
-            $end = count($item['translations']);
+            $end = is_countable($item['translations']) ? count($item['translations']) : 0;
             for ($i = 0; $i < $end; $i++) {
                 if (!in_array($item['translations'][$i]['locale'], $locales)) {
                     unset($item['translations'][$i]);
@@ -224,7 +224,6 @@ class TransUnitRepository extends DocumentRepository
     /**
      * Returns all translations for the given file.
      *
-     * @param ModelFile $file
      * @param boolean   $onlyUpdated
      * @return array
      */
@@ -242,7 +241,7 @@ class TransUnitRepository extends DocumentRepository
         foreach ($results as $result) {
             $content = null;
             $i = 0;
-            while ($i < count($result['translations']) && null === $content) {
+            while ($i < (is_countable($result['translations']) ? count($result['translations']) : 0) && null === $content) {
                 if ($file->getLocale() == $result['translations'][$i]['locale']) {
                     if ($onlyUpdated) {
                         $updated = ($result['translations'][$i]['createdAt'] < $result['translations'][$i]['updatedAt']);
@@ -264,9 +263,6 @@ class TransUnitRepository extends DocumentRepository
 
     /**
      * Add conditions according to given filters.
-     *
-     * @param Builder $builder
-     * @param array   $filters
      */
     protected function addTransUnitFilters(Builder $builder, array $filters = null)
     {
@@ -308,7 +304,7 @@ class TransUnitRepository extends DocumentRepository
             $ids = $qb->getQuery()->execute();
             //$ids = iterator_to_array($ids);
 
-            if (count($ids) > 0) {
+            if (($ids === null ? 0 : count($ids)) > 0) {
                 $builder->field('id')->in($ids);
             }
         }
@@ -359,7 +355,7 @@ FCT;
                         ->getQuery()
                         ->execute();
 
-        return isset($results[0]['count']) ? $results[0]['count'] : [];
+        return $results[0]['count'] ?? [];
     }
 
     /**
@@ -392,6 +388,6 @@ FCT;
                         ->getQuery()
                         ->execute();
 
-        return isset($results[0]['count']) ? $results[0]['count'] : [];
+        return $results[0]['count'] ?? [];
     }
 }

--- a/Entity/FileRepository.php
+++ b/Entity/FileRepository.php
@@ -14,8 +14,6 @@ class FileRepository extends EntityRepository
     /**
      * Returns all files matching a given locale and a given domains.
      *
-     * @param array $locales
-     * @param array $domains
      * @return array
      */
     public function findForLocalesAndDomains(array $locales, array $domains)

--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -68,18 +68,16 @@ class TransUnitRepository extends EntityRepository
     /**
      * Returns some trans units with their translations.
      *
-     * @param array $locales
      * @param int   $rows
      * @param int   $page
-     * @param array $filters
      * @return array
      */
     public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null)
     {
         $this->loadCustomHydrator();
 
-        $sortColumn = isset($filters['sidx']) ? $filters['sidx'] : 'id';
-        $order = isset($filters['sord']) ? $filters['sord'] : 'ASC';
+        $sortColumn = $filters['sidx'] ?? 'id';
+        $order = $filters['sord'] ?? 'ASC';
 
         $builder = $this->createQueryBuilder('tu')
             ->select('tu.id');
@@ -93,9 +91,9 @@ class TransUnitRepository extends EntityRepository
             ->getQuery()
             ->getResult('SingleColumnArrayHydrator');
 
-        $transUnits = array();
+        $transUnits = [];
 
-        if (count($ids) > 0) {
+        if ((is_countable($ids) ? count($ids) : 0) > 0) {
             $qb = $this->createQueryBuilder('tu');
 
             $transUnits = $qb->select('tu, te')
@@ -113,8 +111,6 @@ class TransUnitRepository extends EntityRepository
     /**
      * Count the number of trans unit.
      *
-     * @param array $locales
-     * @param array $filters
      * @return int
      */
     public function count(array $locales = null,  array $filters = null)
@@ -145,7 +141,6 @@ class TransUnitRepository extends EntityRepository
     /**
      * Returns all translations for the given file.
      *
-     * @param ModelFile $file
      * @param boolean   $onlyUpdated
      * @return array
      */
@@ -164,7 +159,7 @@ class TransUnitRepository extends EntityRepository
 
         $results = $builder->getQuery()->getArrayResult();
 
-        $translations = array();
+        $translations = [];
         foreach ($results as $result) {
             $translations[$result['key']] = $result['content'];
         }
@@ -174,9 +169,6 @@ class TransUnitRepository extends EntityRepository
 
     /**
      * Add conditions according to given filters.
-     *
-     * @param QueryBuilder $builder
-     * @param array        $filters
      */
     protected function addTransUnitFilters(QueryBuilder $builder, array $filters = null)
     {
@@ -195,10 +187,6 @@ class TransUnitRepository extends EntityRepository
 
     /**
      * Add conditions according to given filters.
-     *
-     * @param QueryBuilder $builder
-     * @param array        $locales
-     * @param array        $filters
      */
     protected function addTranslationFilter(QueryBuilder $builder, array $locales = null, array $filters = null)
     {
@@ -220,7 +208,7 @@ class TransUnitRepository extends EntityRepository
 
             $ids = $qb->getQuery()->getResult('SingleColumnArrayHydrator');
 
-            if (count($ids) > 0) {
+            if ((is_countable($ids) ? count($ids) : 0) > 0) {
                 $builder->andWhere($builder->expr()->in('tu.id', $ids));
             }
         }
@@ -232,6 +220,6 @@ class TransUnitRepository extends EntityRepository
     protected function loadCustomHydrator()
     {
         $config = $this->getEntityManager()->getConfiguration();
-        $config->addCustomHydrationMode('SingleColumnArrayHydrator', 'Lexik\Bundle\TranslationBundle\Util\Doctrine\SingleColumnArrayHydrator');
+        $config->addCustomHydrationMode('SingleColumnArrayHydrator', \Lexik\Bundle\TranslationBundle\Util\Doctrine\SingleColumnArrayHydrator::class);
     }
 }

--- a/EventDispatcher/CleanTranslationCacheListener.php
+++ b/EventDispatcher/CleanTranslationCacheListener.php
@@ -13,52 +13,15 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class CleanTranslationCacheListener
 {
-    /**
-     * @var StorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var string
-     */
-    private $cacheDirectory;
-
-    /**
-     * @var LocaleManagerInterface
-     */
-    private $localeManager;
-
-    /**
-     * @var int
-     */
-    private $cacheInterval;
-
-    /**
-     * Constructor
-     *
-     * @param StorageInterface       $storage
-     * @param TranslatorInterface    $translator
-     * @param string                 $cacheDirectory
-     * @param LocaleManagerInterface $localeManager
-     * @param int                    $cacheInterval
-     */
-    public function __construct(StorageInterface $storage, TranslatorInterface $translator, $cacheDirectory, LocaleManagerInterface $localeManager, $cacheInterval)
-    {
-        $this->storage = $storage;
-        $this->cacheDirectory = $cacheDirectory;
-        $this->translator = $translator;
-        $this->localeManager = $localeManager;
-        $this->cacheInterval = $cacheInterval;
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly TranslatorInterface $translator,
+        private readonly string$cacheDirectory,
+        private readonly LocaleManagerInterface $localeManager,
+        private readonly int $cacheInterval,
+    ) {
     }
 
-    /**
-     * @param RequestEvent $event
-     */
     public function onKernelRequest(RequestEvent $event)
     {
         if ($event->isMainRequest() && $this->isCacheExpired()) {

--- a/EventDispatcher/GetDatabaseResourcesListener.php
+++ b/EventDispatcher/GetDatabaseResourcesListener.php
@@ -10,25 +10,20 @@ use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
  */
 class GetDatabaseResourcesListener
 {
-    private StorageInterface $storage;
-    private string $storageType;
-
-    public function __construct(StorageInterface $storage, string $storageType)
-    {
-        $this->storage = $storage;
-        $this->storageType = $storageType;
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly string $storageType,
+    ) {
     }
 
     /**
      * Query the database to get translation resources and set it on the event.
-     *
-     * @param GetDatabaseResourcesEvent $event
      */
     public function onGetDatabaseResources(GetDatabaseResourcesEvent $event)
     {
         // prevent errors on command such as cache:clear if doctrine schema has not been updated yet
         if (StorageInterface::STORAGE_ORM == $this->storageType && !$this->storage->translationsTablesExist()) {
-            $resources = array();
+            $resources = [];
         } else {
             $resources = $this->storage->getTransUnitDomainsByLocale();
         }

--- a/Form/Handler/FormHandlerInterface.php
+++ b/Form/Handler/FormHandlerInterface.php
@@ -27,8 +27,6 @@ interface FormHandlerInterface
     /**
      * Process the form and returns true if the form is valid.
      *
-     * @param FormInterface $form
-     * @param Request $request
      * @return boolean
      */
     public function process(FormInterface $form, Request $request);

--- a/Form/Handler/TransUnitFormHandler.php
+++ b/Form/Handler/TransUnitFormHandler.php
@@ -17,44 +17,15 @@ use Symfony\Component\HttpFoundation\Request;
 class TransUnitFormHandler implements FormHandlerInterface
 {
     /**
-     * @var TransUnitManagerInterface
+     * @param string $rootDir
      */
-    protected $transUnitManager;
-
-    /**
-     * @var FileManagerInterface
-     */
-    protected $fileManager;
-
-    /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
-     * @var LocaleManagerInterface
-     */
-    protected $localeManager;
-
-    /**
-     * @var string
-     */
-    protected $rootDir;
-
-    /**
-     * @param TransUnitManagerInterface $transUnitManager
-     * @param FileManagerInterface      $fileManager
-     * @param StorageInterface          $storage
-     * @param LocaleManagerInterface    $localeManager
-     * @param string                    $rootDir
-     */
-    public function __construct(TransUnitManagerInterface $transUnitManager, FileManagerInterface $fileManager, StorageInterface $storage, LocaleManagerInterface $localeManager, $rootDir)
-    {
-        $this->transUnitManager = $transUnitManager;
-        $this->fileManager = $fileManager;
-        $this->storage = $storage;
-        $this->localeManager = $localeManager;
-        $this->rootDir = $rootDir;
+    public function __construct(
+        protected TransUnitManagerInterface $transUnitManager,
+        protected FileManagerInterface $fileManager,
+        protected StorageInterface $storage,
+        protected LocaleManagerInterface $localeManager,
+        protected string $rootDir,
+    ) {
     }
 
     /**
@@ -70,11 +41,11 @@ class TransUnitFormHandler implements FormHandlerInterface
      */
     public function getFormOptions()
     {
-        return array(
+        return [
             'domains'           => $this->storage->getTransUnitDomains(),
             'data_class'        => $this->storage->getModelClass('trans_unit'),
             'translation_class' => $this->storage->getModelClass('translation'),
-        );
+        ];
     }
 
     /**
@@ -96,7 +67,7 @@ class TransUnitFormHandler implements FormHandlerInterface
                     if (!$translation->getFile()) {
                         $file = $this->fileManager->getFor(
                             sprintf('%s.%s.yml', $transUnit->getDomain(), $translation->getLocale()),
-                            $this->rootDir.'/Resources/translations'
+                            $this->rootDir . '/Resources/translations'
                         );
 
                         if ($file instanceof FileInterface) {

--- a/Form/Type/TransUnitType.php
+++ b/Form/Type/TransUnitType.php
@@ -18,30 +18,14 @@ class TransUnitType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('key', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
-            'label' => 'translations.key',
-        ));
-        $builder->add('domain', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
-            'label'   => 'translations.domain',
-            'choices' => array_merge(
-                array_combine($options['default_domain'], $options['default_domain']),
-                array_combine($options['domains'], $options['domains'])
-            ),
-        ));
-        $builder->add('translations', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', array(
-            'entry_type'     => 'Lexik\Bundle\TranslationBundle\Form\Type\TranslationType',
-            'label'    => 'translations.page_title',
-            'required' => false,
-            'entry_options'  => array(
-                'data_class' => $options['translation_class'],
-            ),
-        ));
-        $builder->add('save', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', array(
-            'label' => 'translations.save',
-        ));
-        $builder->add('save_add', 'Symfony\Component\Form\Extension\Core\Type\SubmitType', array(
-            'label' => 'translations.save_add',
-        ));
+        $builder->add('key', \Symfony\Component\Form\Extension\Core\Type\TextType::class, ['label' => 'translations.key']);
+        $builder->add('domain', \Symfony\Component\Form\Extension\Core\Type\ChoiceType::class, ['label'   => 'translations.domain', 'choices' => array_merge(
+            array_combine($options['default_domain'], $options['default_domain']),
+            array_combine($options['domains'], $options['domains'])
+        )]);
+        $builder->add('translations', \Symfony\Component\Form\Extension\Core\Type\CollectionType::class, ['entry_type'     => \Lexik\Bundle\TranslationBundle\Form\Type\TranslationType::class, 'label'    => 'translations.page_title', 'required' => false, 'entry_options'  => ['data_class' => $options['translation_class']]]);
+        $builder->add('save', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, ['label' => 'translations.save']);
+        $builder->add('save_add', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, ['label' => 'translations.save_add']);
     }
 
     /**
@@ -49,13 +33,7 @@ class TransUnitType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class'         => null,
-            'default_domain'     => ['messages'],
-            'domains'            => [],
-            'translation_class'  => null,
-            'translation_domain' => 'LexikTranslationBundle',
-        ));
+        $resolver->setDefaults(['data_class'         => null, 'default_domain'     => ['messages'], 'domains'            => [], 'translation_class'  => null, 'translation_domain' => 'LexikTranslationBundle']);
     }
 
     /**

--- a/Form/Type/TranslationType.php
+++ b/Form/Type/TranslationType.php
@@ -3,6 +3,8 @@
 namespace Lexik\Bundle\TranslationBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
@@ -20,10 +22,8 @@ class TranslationType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('locale', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
-        $builder->add('content', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
-            'required' => false,
-        ));
+        $builder->add('locale', HiddenType::class);
+        $builder->add('content', TextareaType::class, ['required' => false]);
     }
 
     /**
@@ -39,10 +39,7 @@ class TranslationType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class'         => null,
-            'translation_domain' => 'LexikTranslationBundle',
-        ));
+        $resolver->setDefaults(['data_class'         => null, 'translation_domain' => 'LexikTranslationBundle']);
     }
 
     /**

--- a/Manager/FileManager.php
+++ b/Manager/FileManager.php
@@ -13,25 +13,14 @@ use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 class FileManager implements FileManagerInterface
 {
     /**
-     * @var StorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var string
-     */
-    private $rootDir;
-
-    /**
      * Construct.
      *
-     * @param StorageInterface $storage
-     * @param string           $rootDir
+     * @param string $rootDir
      */
-    public function __construct(StorageInterface $storage, $rootDir)
-    {
-        $this->storage = $storage;
-        $this->rootDir = $rootDir;
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private $rootDir,
+    ) {
     }
 
     /**
@@ -46,7 +35,7 @@ class FileManager implements FileManagerInterface
         $hash = $this->generateHash($name, $this->getFileRelativePath($path));
         $file = $this->storage->getFileByHash($hash);
 
-        return $file instanceof FileInterface? $file : $this->create($name, $path);
+        return $file instanceof FileInterface ? $file : $this->create($name, $path);
 
     }
 
@@ -82,7 +71,7 @@ class FileManager implements FileManagerInterface
      */
     protected function generateHash($name, $relativePath)
     {
-        return md5($relativePath.DIRECTORY_SEPARATOR.$name);
+        return md5($relativePath . DIRECTORY_SEPARATOR . $name);
     }
 
     /**
@@ -93,13 +82,13 @@ class FileManager implements FileManagerInterface
      */
     protected function getFileRelativePath($filePath)
     {
-        $commonParts = array();
+        $commonParts = [];
 
         // replace window \ to work with /
-        $rootDir = (false !== strpos($this->rootDir, '\\')) ? str_replace('\\', '/', $this->rootDir) : $this->rootDir;
+        $rootDir = (str_contains($this->rootDir, '\\')) ? str_replace('\\', '/', $this->rootDir) : $this->rootDir;
 
         $antiSlash = false;
-        if (false !== strpos($filePath, '\\')) {
+        if (str_contains($filePath, '\\')) {
             $filePath = str_replace('\\', '/', $filePath);
             $antiSlash = true;
         }
@@ -115,13 +104,13 @@ class FileManager implements FileManagerInterface
             $i++;
         }
 
-        $filePath = str_replace(implode('/', $commonParts).'/', '', $filePath);
+        $filePath = str_replace(implode('/', $commonParts) . '/', '', $filePath);
 
         $nbCommonParts = count($commonParts);
         $nbRootParts = count($rootDirParts);
 
         for ($i = $nbCommonParts; $i < $nbRootParts; $i++) {
-             $filePath = '../'.$filePath;
+            $filePath = '../' . $filePath;
         }
 
         return $antiSlash ? str_replace('/', '\\', $filePath) : $filePath;

--- a/Manager/LocaleManager.php
+++ b/Manager/LocaleManager.php
@@ -8,18 +8,11 @@ namespace Lexik\Bundle\TranslationBundle\Manager;
 class LocaleManager implements LocaleManagerInterface
 {
     /**
-     * @var array
-     */
-    protected $managedLocales;
-
-    /**
      * Constructor
-     *
-     * @param array $managedLocales
      */
-    public function __construct(array $managedLocales)
-    {
-        $this->managedLocales = $managedLocales;
+    public function __construct(
+        protected array $managedLocales
+    ) {
     }
 
     /**

--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -13,39 +13,17 @@ use Lexik\Bundle\TranslationBundle\Storage\PropelStorage;
  */
 class TransUnitManager implements TransUnitManagerInterface
 {
-    /**
-     * @var StorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var FileManagerInterface
-     */
-    private $fileManager;
-
-    /**
-     * @var String
-     */
-    private $kernelRootDir;
-
-    /**
-     * Construct.
-     *
-     * @param StorageInterface $storage
-     * @param FileManagerInterface $fm
-     * @param String $kernelRootDir
-     */
-    public function __construct(StorageInterface $storage, FileManagerInterface $fm, $kernelRootDir)
-    {
-        $this->storage = $storage;
-        $this->fileManager = $fm;
-        $this->kernelRootDir = $kernelRootDir;
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly FileManagerInterface $fileManager,
+        private string $kernelRootDir,
+    ) {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function newInstance($locales = array())
+    public function newInstance($locales = [])
     {
         $transUnitClass = $this->storage->getModelClass('trans_unit');
         $translationClass = $this->storage->getModelClass('translation');
@@ -83,8 +61,13 @@ class TransUnitManager implements TransUnitManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function addTranslation(TransUnitInterface $transUnit, $locale, $content, FileInterface $file = null, $flush = false)
-    {
+    public function addTranslation(
+        TransUnitInterface $transUnit,
+        $locale,
+        $content,
+        FileInterface $file = null,
+        $flush = false
+    ) {
         $translation = null;
 
         if (!$transUnit->hasTranslation($locale)) {
@@ -195,13 +178,8 @@ class TransUnitManager implements TransUnitManagerInterface
 
     /**
      * Get the proper File for this TransUnit and locale
-     *
-     * @param TransUnitInterface $transUnit
-     * @param string $locale
-     *
-     * @return FileInterface|null
      */
-    public function getTranslationFile(TransUnitInterface & $transUnit, $locale)
+    public function getTranslationFile(TransUnitInterface &$transUnit, string $locale)
     {
         $file = null;
         foreach ($transUnit->getTranslations() as $translation) {
@@ -214,14 +192,13 @@ class TransUnitManager implements TransUnitManagerInterface
         if ($file !== null) {
             //make sure we got the correct file for this locale and domain
             $name = sprintf('%s.%s.%s', $file->getDomain(), $locale, $file->getExtention());
-            $file = $this->fileManager->getFor($name, $this->kernelRootDir.DIRECTORY_SEPARATOR.$file->getPath());
+            $file = $this->fileManager->getFor($name, $this->kernelRootDir . DIRECTORY_SEPARATOR . $file->getPath());
         }
 
         return $file;
     }
 
     /**
-     * @param TransUnitInterface $transUnit
      * @return bool
      */
     public function delete(TransUnitInterface $transUnit)
@@ -232,14 +209,13 @@ class TransUnitManager implements TransUnitManagerInterface
 
             return true;
 
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
 
     /**
-     * @param TransUnitInterface $transUnit
-     * @param string             $locale
+     * @param string $locale
      * @return bool
      */
     public function deleteTranslation(TransUnitInterface $transUnit, $locale)
@@ -252,7 +228,7 @@ class TransUnitManager implements TransUnitManagerInterface
 
             return true;
 
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }

--- a/Manager/TransUnitManagerInterface.php
+++ b/Manager/TransUnitManagerInterface.php
@@ -15,7 +15,7 @@ interface TransUnitManagerInterface
      * @param array $locales
      * @return TransUnitInterface
      */
-    public function newInstance($locales = array());
+    public function newInstance($locales = []);
 
     /**
      * Create a new trans unit.
@@ -30,10 +30,8 @@ interface TransUnitManagerInterface
     /**
      * Add a new translation to the given trans unit.
      *
-     * @param TransUnitInterface    $transUnit
      * @param string                $locale
      * @param string                $content
-     * @param FileInterface         $file
      * @param boolean               $flush
      * @return TranslationInterface
      */
@@ -42,7 +40,6 @@ interface TransUnitManagerInterface
     /**
      * Update the translated content of a trans unit for the given locale.
      *
-     * @param TransUnitInterface    $transUnit
      * @param string                $locale
      * @param string                $content
      * @param boolean               $flush
@@ -54,8 +51,6 @@ interface TransUnitManagerInterface
     /**
      * Update the content of each translations for the given trans unit.
      *
-     * @param TransUnitInterface    $transUnit
-     * @param array                 $translations
      * @param boolean               $flush
      */
     public function updateTranslationsContent(TransUnitInterface $transUnit, array $translations, $flush = false);

--- a/Model/File.php
+++ b/Model/File.php
@@ -162,7 +162,7 @@ abstract class File
      */
     public function setName($name)
     {
-        list($domain, $locale, $extention) = explode('.', $name);
+        [$domain, $locale, $extention] = explode('.', $name);
 
         $this->domain = $domain;
         $this->locale = $locale;
@@ -201,8 +201,6 @@ abstract class File
 
     /**
      * Add translation
-     *
-     * @param Lexik\Bundle\TranslationBundle\Model\Translation $translation
      */
     public function addTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation)
     {

--- a/Model/TransUnit.php
+++ b/Model/TransUnit.php
@@ -166,8 +166,6 @@ abstract class TransUnit
 
     /**
      * Set translations collection
-     *
-     * @param Collection $collection
      */
     public function setTranslations(Collection $collection)
     {

--- a/Model/Translation.php
+++ b/Model/Translation.php
@@ -87,11 +87,6 @@ abstract class Translation
         return $this->content;
     }
 
-    /**
-     * Set file
-     *
-     * @param File $file
-     */
     public function setFile(File $file)
     {
         $this->file = $file;

--- a/Propel/File.php
+++ b/Propel/File.php
@@ -14,7 +14,7 @@ class File extends BaseFile implements FileInterface
      */
     public function setName($name)
     {
-        list($domain, $locale, $extention) = explode('.', $name);
+        [$domain, $locale, $extention] = explode('.', $name);
 
         $this
             ->setDomain($domain)

--- a/Propel/FileRepository.php
+++ b/Propel/FileRepository.php
@@ -12,14 +12,9 @@ use Propel\Runtime\Connection\ConnectionWrapper;
  */
 class FileRepository
 {
-    /**
-     * @var ConnectionWrapper
-     */
-    protected $connection;
-
-    public function __construct(ConnectionWrapper $connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        protected ConnectionWrapper $connection
+    ) {
     }
 
     /**
@@ -33,22 +28,17 @@ class FileRepository
     /**
      * Returns all files matching a given locale and a given domains.
      *
-     * @param array $locales
-     * @param array $domains
      * @return array
      */
     public function findForLocalesAndDomains(array $locales, array $domains)
     {
         return FileQuery::create()
-            ->_if(count($locales) > 0)
-                ->filterByLocale($locales, Criteria::IN)
-            ->_endif()
-
-            ->_if(count($domains) > 0)
-                ->filterByDomain($domains, Criteria::IN)
-            ->_endif()
-
-            ->find($this->getConnection())
-        ;
+                        ->_if(count($locales) > 0)
+                        ->filterByLocale($locales, Criteria::IN)
+                        ->_endif()
+                        ->_if(count($domains) > 0)
+                        ->filterByDomain($domains, Criteria::IN)
+                        ->_endif()
+                        ->find($this->getConnection());
     }
 }

--- a/Propel/TransUnit.php
+++ b/Propel/TransUnit.php
@@ -6,17 +6,16 @@ use Lexik\Bundle\TranslationBundle\Model\Translation;
 use Lexik\Bundle\TranslationBundle\Propel\Base\TransUnit as BaseTransUnit;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
+use Propel\Runtime\ActiveQuery\Criteria;
 
 class TransUnit extends BaseTransUnit implements TransUnitInterface
 {
-    protected $translations = array();
+    protected $translations = [];
 
     /**
      * Return translations with  not blank content.
-     *
-     * @return array
      */
-    public function filterNotBlankTranslations()
+    public function filterNotBlankTranslations(): array
     {
         return array_filter($this->getTranslations()->getArrayCopy(), function (TranslationInterface $translation) {
             $content = $translation->getContent();
@@ -28,7 +27,7 @@ class TransUnit extends BaseTransUnit implements TransUnitInterface
     /** (non-PHPdoc)
      * @see \Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface::hasTranslation()
      */
-    public function hasTranslation($locale)
+    public function hasTranslation($locale): bool
     {
         return null !== $this->getTranslation($locale);
     }

--- a/Propel/TranslationRepository.php
+++ b/Propel/TranslationRepository.php
@@ -12,17 +12,9 @@ use Lexik\Bundle\TranslationBundle\Propel\Map\TranslationTableMap;
  */
 class TranslationRepository
 {
-    /**
-     * @var ConnectionWrapper
-     */
-    protected $connection;
-
-    /**
-     * @param ConnectionWrapper $connection
-     */
-    public function __construct(ConnectionWrapper $connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        protected ConnectionWrapper $connection
+    ) {
     }
 
     /**
@@ -39,10 +31,9 @@ class TranslationRepository
     public function getLatestTranslationUpdatedAt()
     {
         $result = TranslationQuery::create()
-            ->withColumn(sprintf('MAX(%s)', TranslationTableMap::COL_UPDATED_AT), 'max_updated_at')
-            ->select(array('max_updated_at'))
-            ->findOne($this->getConnection())
-        ;
+                                  ->withColumn(sprintf('MAX(%s)', TranslationTableMap::COL_UPDATED_AT), 'max_updated_at')
+                                  ->select(['max_updated_at'])
+                                  ->findOne($this->getConnection());
 
         return !empty($result) ? new \DateTime($result) : null;
     }

--- a/Storage/AbstractDoctrineStorage.php
+++ b/Storage/AbstractDoctrineStorage.php
@@ -12,26 +12,11 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
  */
 abstract class AbstractDoctrineStorage implements StorageInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
-    protected $registry;
-
-    /**
-     * @var string
-     */
-    protected $managerName;
-
-    /**
-     * @var array
-     */
-    protected $classes;
-
-    public function __construct(ManagerRegistry $registry, string $managerName, array $classes)
-    {
-        $this->registry = $registry;
-        $this->managerName = $managerName;
-        $this->classes = $classes;
+    public function __construct(
+        protected ManagerRegistry $registry,
+        protected string $managerName,
+        protected array $classes,
+    ) {
     }
 
     protected function getManager(): ObjectManager
@@ -142,10 +127,10 @@ abstract class AbstractDoctrineStorage implements StorageInterface
     {
         $key = mb_substr($key, 0, 255, 'UTF-8');
 
-        $fields = array(
+        $fields = [
             'key'    => $key,
             'domain' => $domain,
-        );
+        ];
 
         return $this->getTransUnitRepository()->findOneBy($fields);
     }

--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -39,9 +39,7 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
                 $tmpConnection = DriverManager::getConnection($params);
                 $dbExists = in_array($connection->getDatabase(), $tmpConnection->getSchemaManager()->listDatabases());
                 $tmpConnection->close();
-            } catch (ConnectionException $e) {
-                $dbExists = false;
-            } catch (\Exception $e) {
+            } catch (ConnectionException|\Exception $e) {
                 $dbExists = false;
             }
 
@@ -51,10 +49,10 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
         }
 
         // checks tables exist
-        $tables = array(
+        $tables = [
             $em->getClassMetadata($this->getModelClass('trans_unit'))->getTableName(),
             $em->getClassMetadata($this->getModelClass('translation'))->getTableName(),
-        );
+        ];
 
         return $connection->getSchemaManager()->tablesExist($tables);
     }
@@ -74,9 +72,9 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
     {
         $results = $this->getTransUnitRepository()->countByDomains();
 
-        $counts = array();
+        $counts = [];
         foreach ($results as $row) {
-            $counts[$row['domain']] = (int) $row['number'];
+            $counts[$row['domain']] = (int)$row['number'];
         }
 
         return $counts;
@@ -89,9 +87,9 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
     {
         $results = $this->getTranslationRepository()->countByLocales($domain);
 
-        $counts = array();
+        $counts = [];
         foreach ($results as $row) {
-            $counts[$row['locale']] = (int) $row['number'];
+            $counts[$row['locale']] = (int)$row['number'];
         }
 
         return $counts;

--- a/Storage/Listener/DoctrineORMListener.php
+++ b/Storage/Listener/DoctrineORMListener.php
@@ -7,9 +7,6 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 class DoctrineORMListener
 {
-    /**
-     * @param LoadClassMetadataEventArgs $eventArgs
-     */
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
     {
         $params = $eventArgs->getEntityManager()->getConnection()->getParams();
@@ -21,7 +18,7 @@ class DoctrineORMListener
         /** @var ClassMetadataInfo $metadata */
         $metadata = $eventArgs->getClassMetadata();
 
-        if (false === strpos($metadata->getName(), 'TranslationBundle')) {
+        if (!str_contains($metadata->getName(), 'TranslationBundle')) {
             return;
         }
 

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -14,9 +14,9 @@ interface StorageInterface
     /**
      * All the available config storage types.
      */
-    const STORAGE_ORM     = 'orm';
-    const STORAGE_MONGODB = 'mongodb';
-    const STORAGE_PROPEL  = 'propel';
+    public const STORAGE_ORM     = 'orm';
+    public const STORAGE_MONGODB = 'mongodb';
+    public const STORAGE_PROPEL  = 'propel';
 
     /**
      * Persist the given object.
@@ -56,8 +56,6 @@ interface StorageInterface
     /**
      * Returns all files matching a given locale and a given domains.
      *
-     * @param array $locales
-     * @param array $domains
      * @return array
      */
     public function getFilesByLocalesAndDomains(array $locales, array $domains);
@@ -112,10 +110,8 @@ interface StorageInterface
     /**
      * Returns some trans units with their translations.
      *
-     * @param array $locales
      * @param int   $rows
      * @param int   $page
-     * @param array $filters
      * @return array
      */
     public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null);
@@ -123,8 +119,6 @@ interface StorageInterface
     /**
      * Count the number of trans unit.
      *
-     * @param array $locales
-     * @param array $filters
      * @return int
      */
     public function countTransUnits(array $locales = null,  array $filters = null);

--- a/Tests/Command/ImportTranslationsCommandTest.php
+++ b/Tests/Command/ImportTranslationsCommandTest.php
@@ -19,10 +19,7 @@ use Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand;
  */
 class ImportTranslationsCommandTest extends WebTestCase
 {
-    /**
-     * @var Application
-     */
-    private static $application;
+    private static Application $application;
 
     /**
      *
@@ -55,11 +52,11 @@ class ImportTranslationsCommandTest extends WebTestCase
     {
         static::$kernel->getContainer()->get('doctrine.dbal.default_connection');
 
-        static::runCommand("doctrine:schema:drop", array('--force' => true));
+        static::runCommand("doctrine:schema:drop", ['--force' => true]);
         static::runCommand("doctrine:schema:create");
     }
 
-    private static function runCommand($commandName, $options = array())
+    private static function runCommand($commandName, $options = [])
     {
         $options["-e"] = self::$kernel->getEnvironment();
 
@@ -91,13 +88,13 @@ class ImportTranslationsCommandTest extends WebTestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
-            array(
+            [
                 'command'       => $command->getName(),
                 'bundle'        => 'LexikTranslationBundle',
                 '--cache-clear' => true,
                 '--force'       => true,
-                '--locales'     => array('en', 'fr'),
-            )
+                '--locales'     => ['en', 'fr'],
+            ]
         );
 
         $resultLines = explode("\n", $commandTester->getDisplay());

--- a/Tests/Fixtures/TransUnitData.php
+++ b/Tests/Fixtures/TransUnitData.php
@@ -24,11 +24,8 @@ class TransUnitData implements FixtureInterface
     public function load(ObjectManager $manager)
     {
         // add files
-        $files = array();
-        $domains = array(
-            'superTranslations' => array('fr', 'en', 'de'),
-            'messages'          => array('fr', 'en'),
-        );
+        $files = [];
+        $domains = ['superTranslations' => ['fr', 'en', 'de'], 'messages' => ['fr', 'en']];
 
         foreach ($domains as $name => $locales) {
             foreach ($locales as $locale) {
@@ -51,11 +48,11 @@ class TransUnitData implements FixtureInterface
         $transUnit->setKey('key.say_hello');
         $transUnit->setDomain('superTranslations');
 
-        $translations = array(
-           'fr' => 'salut',
-           'en' => 'hello',
-           'de' => 'heil',
-        );
+        $translations = [
+            'fr' => 'salut',
+            'en' => 'hello',
+            'de' => 'heil',
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = $this->createTranslationInstance($manager);
@@ -73,10 +70,10 @@ class TransUnitData implements FixtureInterface
         $transUnit = $this->createTransUnitInstance($manager);
         $transUnit->setKey('key.say_goodbye');
 
-        $translations = array(
+        $translations = [
             'fr' => 'au revoir',
             'en' => 'goodbye',
-        );
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = $this->createTranslationInstance($manager);
@@ -94,10 +91,10 @@ class TransUnitData implements FixtureInterface
         $transUnit = $this->createTransUnitInstance($manager);
         $transUnit->setKey('key.say_wtf');
 
-        $translations = array(
+        $translations = [
             'fr' => 'c\'est quoi ce bordel !?!',
             'en' => 'what the fuck !?!',
-        );
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = $this->createTranslationInstance($manager);
@@ -114,8 +111,6 @@ class TransUnitData implements FixtureInterface
 
     /**
      * Create the right TransUnit instance.
-     *
-     * @param ObjectManager $manager
      */
     protected function createTransUnitInstance(ObjectManager $manager)
     {
@@ -132,8 +127,6 @@ class TransUnitData implements FixtureInterface
 
     /**
      * Create the right Translation instance.
-     *
-     * @param ObjectManager $manager
      */
     protected function createTranslationInstance(ObjectManager $manager)
     {
@@ -150,8 +143,6 @@ class TransUnitData implements FixtureInterface
 
     /**
      * Create the right File instance.
-     *
-     * @param ObjectManager $manager
      */
     protected function createFileInstance(ObjectManager $manager)
     {

--- a/Tests/Fixtures/TransUnitDataPropel.php
+++ b/Tests/Fixtures/TransUnitDataPropel.php
@@ -24,11 +24,11 @@ class TransUnitDataPropel
     public function load(ConnectionWrapper $con)
     {
         // add files
-        $files = array();
-        $domains = array(
-            'superTranslations' => array('fr', 'en', 'de'),
-            'messages'          => array('fr', 'en'),
-        );
+        $files = [];
+        $domains = [
+            'superTranslations' => ['fr', 'en', 'de'],
+            'messages'          => ['fr', 'en'],
+        ];
 
         foreach ($domains as $name => $locales) {
             foreach ($locales as $locale) {
@@ -49,11 +49,11 @@ class TransUnitDataPropel
         $transUnit->setKey('key.say_hello');
         $transUnit->setDomain('superTranslations');
 
-        $translations = array(
-           'fr' => 'salut',
-           'en' => 'hello',
-           'de' => 'heil',
-        );
+        $translations = [
+            'fr' => 'salut',
+            'en' => 'hello',
+            'de' => 'heil',
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = new Translation();
@@ -70,10 +70,10 @@ class TransUnitDataPropel
         $transUnit = new TransUnit();
         $transUnit->setKey('key.say_goodbye');
 
-        $translations = array(
+        $translations = [
             'fr' => 'au revoir',
             'en' => 'goodbye',
-        );
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = new Translation();
@@ -90,10 +90,10 @@ class TransUnitDataPropel
         $transUnit = new TransUnit();
         $transUnit->setKey('key.say_wtf');
 
-        $translations = array(
+        $translations = [
             'fr' => 'c\'est quoi ce bordel !?!',
             'en' => 'what the fuck !?!',
-        );
+        ];
 
         foreach ($translations as $locale => $content) {
             $translation = new Translation();

--- a/Tests/Fixtures/test.fr.php
+++ b/Tests/Fixtures/test.fr.php
@@ -1,5 +1,5 @@
 <?php
-return array(
+return [
     'key.dude'  => 'Hey mec :D',
     'key.stuff' => 'Truc cool',
-);
+];

--- a/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
+++ b/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
@@ -37,20 +37,20 @@ class CleanTranslationCacheListenerTest extends TestCase
 
         \touch($this->tempDir . '/messages.en.yml', time() - 3600);
 
-        $storage = $this->getMockBuilder('Lexik\Bundle\TranslationBundle\Storage\StorageInterface')
+        $storage = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Storage\StorageInterface::class)
                 ->disableOriginalConstructor()
-                ->setMethods(array())
+                ->setMethods([])
                 ->getMock();
 
         $storage->expects($this->any())->method('getLatestUpdatedAt')->will($this->returnValue($date));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMock(\Symfony\Component\DependencyInjection\ContainerInterface::class);
 
-        $translator = $this->getMock('Lexik\Bundle\TranslationBundle\Translation\Translator', array(), array($container, new MessageSelector));
+        $translator = $this->getMock(\Lexik\Bundle\TranslationBundle\Translation\Translator::class, [], [$container, new MessageSelector]);
 
         $translator->expects($this->any())->method('removeLocalesCacheFiles')->will($this->returnValue(true));
 
-        $listener = new CleanTranslationCacheListener($storage, $translator, \sys_get_temp_dir(), array('en'), 600);
+        $listener = new CleanTranslationCacheListener($storage, $translator, \sys_get_temp_dir(), ['en'], 600);
 
         $event = $this->getEvent($request);
 
@@ -68,7 +68,7 @@ class CleanTranslationCacheListenerTest extends TestCase
 
     private function getEvent(Request $request)
     {
-        return new GetResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST);
+        return new GetResponseEvent($this->getMock(\Symfony\Component\HttpKernel\HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
     private function countFiles($lastUpdateTime)

--- a/Tests/Unit/Repository/Document/FileRepositoryTest.php
+++ b/Tests/Unit/Repository/Document/FileRepositoryTest.php
@@ -22,35 +22,23 @@ class FileRepositoryTest extends BaseUnitTestCase
 
         $repository = $dm->getRepository(self::DOCUMENT_FILE_CLASS);
 
-        $result = $repository->findForLocalesAndDomains(array('de'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.de.yml',
-        );
-        $this->assertEquals(1, count($result));
+        $result = $repository->findForLocalesAndDomains(['de'], []);
+        $expected = ['Resources/translations/superTranslations.de.yml'];
+        $this->assertEquals(1, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array('fr'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.fr.yml',
-            'Resources/translations/messages.fr.yml',
-        );
-        $this->assertEquals(2, count($result));
+        $result = $repository->findForLocalesAndDomains(['fr'], []);
+        $expected = ['Resources/translations/superTranslations.fr.yml', 'Resources/translations/messages.fr.yml'];
+        $this->assertEquals(2, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array(), array('messages'));
-        $expected = array(
-            'Resources/translations/messages.fr.yml',
-            'Resources/translations/messages.en.yml',
-        );
-        $this->assertEquals(2, count($result));
+        $result = $repository->findForLocalesAndDomains([], ['messages']);
+        $expected = ['Resources/translations/messages.fr.yml', 'Resources/translations/messages.en.yml'];
+        $this->assertEquals(2, is_countable($result) ? count($result) : 0);
 
-        $result = $repository->findForLocalesAndDomains(array('en', 'de'), array('messages', 'superTranslations'));
-        $expected = array(
-            'Resources/translations/superTranslations.en.yml',
-            'Resources/translations/superTranslations.de.yml',
-            'Resources/translations/messages.en.yml',
-        );
-        $this->assertEquals(3, count($result));
+        $result = $repository->findForLocalesAndDomains(['en', 'de'], ['messages', 'superTranslations']);
+        $expected = ['Resources/translations/superTranslations.en.yml', 'Resources/translations/superTranslations.de.yml', 'Resources/translations/messages.en.yml'];
+        $this->assertEquals(3, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
     }
 

--- a/Tests/Unit/Repository/Document/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Document/TransUnitRepositoryTest.php
@@ -38,7 +38,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
      */
     public function testGetAllDomains()
     {
-        $dm = $this->loadDatabase(true);
+        $dm = $this->loadDatabase();
         $repository = $dm->getRepository(self::DOCUMENT_TRANS_UNIT_CLASS);
 
         $results = $repository->getAllDomains();
@@ -90,7 +90,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
      */
     public function testCount()
     {
-        $dm = $this->loadDatabase(true);
+        $dm = $this->loadDatabase();
         $repository = $dm->getRepository(self::DOCUMENT_TRANS_UNIT_CLASS);
 
         $this->assertEquals(3, $repository->count(null, []));
@@ -110,7 +110,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
      */
     public function testGetTransUnitList()
     {
-        $dm = $this->loadDatabase(true);
+        $dm = $this->loadDatabase();
         $repository = $dm->getRepository(self::DOCUMENT_TRANS_UNIT_CLASS);
 
         $result = $repository->getTransUnitList(['fr', 'de'], 10, 1, ['sidx' => 'key', 'sord' => 'ASC']);
@@ -269,13 +269,13 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
 
     protected function assertSameTransUnit($expected, $result)
     {
-        $this->assertEquals(count($expected), count($result));
+        $this->assertEquals(is_countable($expected) ? count($expected) : 0, is_countable($result) ? count($result) : 0);
 
         foreach ($expected as $i => $transUnit) {
             $this->assertEquals($transUnit['key'], $result[$i]['key']);
             $this->assertEquals($transUnit['domain'], $result[$i]['domain']);
 
-            $this->assertEquals(count($transUnit['translations']), count($result[$i]['translations']));
+            $this->assertEquals(is_countable($transUnit['translations']) ? count($transUnit['translations']) : 0, is_countable($result[$i]['translations']) ? count($result[$i]['translations']) : 0);
 
             foreach ($transUnit['translations'] as $j => $translation) {
                 $this->assertEquals($translation['locale'], $result[$i]['translations'][$j]['locale']);

--- a/Tests/Unit/Repository/Entity/FileRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/FileRepositoryTest.php
@@ -22,35 +22,23 @@ class FileRepositoryTest extends BaseUnitTestCase
 
         $repository = $em->getRepository(self::ENTITY_FILE_CLASS);
 
-        $result = $repository->findForLocalesAndDomains(array('de'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.de.yml',
-        );
-        $this->assertEquals(1, count($result));
+        $result = $repository->findForLocalesAndDomains(['de'], []);
+        $expected = ['Resources/translations/superTranslations.de.yml'];
+        $this->assertEquals(1, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array('fr'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.fr.yml',
-            'Resources/translations/messages.fr.yml',
-        );
-        $this->assertEquals(2, count($result));
+        $result = $repository->findForLocalesAndDomains(['fr'], []);
+        $expected = ['Resources/translations/superTranslations.fr.yml', 'Resources/translations/messages.fr.yml'];
+        $this->assertEquals(2, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array(), array('messages'));
-        $expected = array(
-            'Resources/translations/messages.fr.yml',
-            'Resources/translations/messages.en.yml',
-        );
-        $this->assertEquals(2, count($result));
+        $result = $repository->findForLocalesAndDomains([], ['messages']);
+        $expected = ['Resources/translations/messages.fr.yml', 'Resources/translations/messages.en.yml'];
+        $this->assertEquals(2, is_countable($result) ? count($result) : 0);
 
-        $result = $repository->findForLocalesAndDomains(array('en', 'de'), array('messages', 'superTranslations'));
-        $expected = array(
-            'Resources/translations/superTranslations.en.yml',
-            'Resources/translations/superTranslations.de.yml',
-            'Resources/translations/messages.en.yml',
-        );
-        $this->assertEquals(3, count($result));
+        $result = $repository->findForLocalesAndDomains(['en', 'de'], ['messages', 'superTranslations']);
+        $expected = ['Resources/translations/superTranslations.en.yml', 'Resources/translations/superTranslations.de.yml', 'Resources/translations/messages.en.yml'];
+        $this->assertEquals(3, is_countable($result) ? count($result) : 0);
         $this->assertFilesPath($expected, $result);
     }
 

--- a/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Entity/TransUnitRepositoryTest.php
@@ -20,13 +20,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
         $results = $repository->getAllDomainsByLocale();
-        $expected = array(
-            array('locale' => 'de', 'domain' => 'superTranslations'),
-            array('locale' => 'en', 'domain' => 'messages'),
-            array('locale' => 'en', 'domain' => 'superTranslations'),
-            array('locale' => 'fr', 'domain' => 'messages'),
-            array('locale' => 'fr', 'domain' => 'superTranslations'),
-        );
+        $expected = [['locale' => 'de', 'domain' => 'superTranslations'], ['locale' => 'en', 'domain' => 'messages'], ['locale' => 'en', 'domain' => 'superTranslations'], ['locale' => 'fr', 'domain' => 'messages'], ['locale' => 'fr', 'domain' => 'superTranslations']];
 
         $this->assertSame($expected, $results);
     }
@@ -40,7 +34,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
         $results = $repository->getAllDomains();
-        $expected = array('messages', 'superTranslations');
+        $expected = ['messages', 'superTranslations'];
 
         $this->assertSame($expected, $results);
     }
@@ -54,20 +48,15 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
         $results = $repository->getAllByLocaleAndDomain('de', 'messages');
-        $expected = array();
+        $expected = [];
         $this->assertSameTransUnit($expected, $results);
 
         $results = $repository->getAllByLocaleAndDomain('de', 'superTranslations');
-        $expected = array(
-            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(array('locale' => 'de', 'content' => 'heil'))),
-        );
+        $expected = [['id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => [['locale' => 'de', 'content' => 'heil']]]];
         $this->assertSameTransUnit($expected, $results);
 
         $results = $repository->getAllByLocaleAndDomain('en', 'messages');
-        $expected = array(
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(array('locale' => 'en', 'content' => 'goodbye'))),
-            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(array('locale' => 'en', 'content' => 'what the fuck !?!'))),
-        );
+        $expected = [['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'en', 'content' => 'goodbye']]], ['id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => [['locale' => 'en', 'content' => 'what the fuck !?!']]]];
         $this->assertSameTransUnit($expected, $results);
     }
 
@@ -79,13 +68,13 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $em = $this->loadDatabase(true);
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
-        $this->assertEquals(3, $repository->count(array('fr', 'de', 'en'), array()));
-        $this->assertEquals(3, $repository->count(array('fr', 'it'), array()));
-        $this->assertEquals(3, $repository->count(array('fr', 'de'), array('_search' => false, 'key' => 'good')));
-        $this->assertEquals(1, $repository->count(array('fr', 'de'), array('_search' => true, 'key' => 'good')));
-        $this->assertEquals(1, $repository->count(array('en', 'de'), array('_search' => true, 'domain' => 'super')));
-        $this->assertEquals(1, $repository->count(array('en', 'fr', 'de'), array('_search' => true, 'key' => 'hel', 'domain' => 'uper')));
-        $this->assertEquals(2, $repository->count(array('en', 'de'), array('_search' => true, 'key' => 'say', 'domain' => 'ssa')));
+        $this->assertEquals(3, $repository->count(['fr', 'de', 'en'], []));
+        $this->assertEquals(3, $repository->count(['fr', 'it'], []));
+        $this->assertEquals(3, $repository->count(['fr', 'de'], ['_search' => false, 'key' => 'good']));
+        $this->assertEquals(1, $repository->count(['fr', 'de'], ['_search' => true, 'key' => 'good']));
+        $this->assertEquals(1, $repository->count(['en', 'de'], ['_search' => true, 'domain' => 'super']));
+        $this->assertEquals(1, $repository->count(['en', 'fr', 'de'], ['_search' => true, 'key' => 'hel', 'domain' => 'uper']));
+        $this->assertEquals(2, $repository->count(['en', 'de'], ['_search' => true, 'key' => 'say', 'domain' => 'ssa']));
     }
 
     /**
@@ -96,70 +85,28 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $em = $this->loadDatabase(true);
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
-        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'ASC'));
-        $expected = array(
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'au revoir'),
-            )),
-            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'de', 'content' => 'heil'),
-                array('locale' => 'fr', 'content' => 'salut'),
-            )),
-            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'de'], 10, 1, ['sidx' => 'key', 'sord' => 'ASC']);
+        $expected = [['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'au revoir']]], ['id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => [['locale' => 'de', 'content' => 'heil'], ['locale' => 'fr', 'content' => 'salut']]], ['id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!']]]];
         $this->assertSameTransUnit($expected, $result);
 
-        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'domain' => 'mess'));
-        $expected = array(
-            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
-            )),
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'au revoir'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'de'], 10, 1, ['sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'domain' => 'mess']);
+        $expected = [['id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!']]], ['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'au revoir']]]];
         $this->assertSameTransUnit($expected, $result);
 
-        $result = $repository->getTransUnitList(array('fr', 'de'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'domain' => 'mess', 'key' => 'oo'));
-        $expected = array(
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'au revoir'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'de'], 10, 1, ['sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'domain' => 'mess', 'key' => 'oo']);
+        $expected = [['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'au revoir']]]];
         $this->assertSameTransUnit($expected, $result);
 
-        $result = $repository->getTransUnitList(array('fr', 'en'), 10, 1, array('sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'fr' => 'alu'));
-        $expected = array(
-            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'en', 'content' => 'hello'),
-                array('locale' => 'fr', 'content' => 'salut'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'en'], 10, 1, ['sidx' => 'key', 'sord' => 'DESC', '_search' => true, 'fr' => 'alu']);
+        $expected = [['id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => [['locale' => 'en', 'content' => 'hello'], ['locale' => 'fr', 'content' => 'salut']]]];
         $this->assertSameTransUnit($expected, $result);
 
-        $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 1, array('sidx' => 'domain', 'sord' => 'ASC'));
-        $expected = array(
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'en', 'content' => 'goodbye'),
-                array('locale' => 'fr', 'content' => 'au revoir'),
-            )),
-            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'en', 'content' => 'what the fuck !?!'),
-                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'de', 'en'], 2, 1, ['sidx' => 'domain', 'sord' => 'ASC']);
+        $expected = [['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'en', 'content' => 'goodbye'], ['locale' => 'fr', 'content' => 'au revoir']]], ['id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => [['locale' => 'en', 'content' => 'what the fuck !?!'], ['locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!']]]];
         $this->assertSameTransUnit($expected, $result);
 
-        $result = $repository->getTransUnitList(array('fr', 'de', 'en'), 2, 2, array('sidx' => 'domain', 'sord' => 'ASC'));
-        $expected = array(
-            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'de', 'content' => 'heil'),
-                array('locale' => 'en', 'content' => 'hello'),
-                array('locale' => 'fr', 'content' => 'salut'),
-            )),
-        );
+        $result = $repository->getTransUnitList(['fr', 'de', 'en'], 2, 2, ['sidx' => 'domain', 'sord' => 'ASC']);
+        $expected = [['id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => [['locale' => 'de', 'content' => 'heil'], ['locale' => 'en', 'content' => 'hello'], ['locale' => 'fr', 'content' => 'salut']]]];
         $this->assertSameTransUnit($expected, $result);
     }
 
@@ -171,18 +118,11 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $em = $this->loadDatabase();
         $repository = $em->getRepository(self::ENTITY_TRANS_UNIT_CLASS);
 
-        $file = $em->getRepository(self::ENTITY_FILE_CLASS)->findOneBy(array(
-            'domain'    => 'messages',
-            'locale'    => 'fr',
-            'extention' => 'yml',
-         ));
+        $file = $em->getRepository(self::ENTITY_FILE_CLASS)->findOneBy(['domain'    => 'messages', 'locale'    => 'fr', 'extention' => 'yml']);
         $this->assertInstanceOf(self::ENTITY_FILE_CLASS, $file);
 
         $result = $repository->getTranslationsForFile($file, false);
-        $expected = array(
-            'key.say_goodbye' => 'au revoir',
-            'key.say_wtf'     => 'c\'est quoi ce bordel !?!',
-        );
+        $expected = ['key.say_goodbye' => 'au revoir', 'key.say_wtf'     => 'c\'est quoi ce bordel !?!'];
         $this->assertEquals($expected, $result);
 
         // update a translation and then get translations with onlyUpdated = true
@@ -200,22 +140,20 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
             ->execute();
 
         $result = $repository->getTranslationsForFile($file, true);
-        $expected = array(
-            'key.say_goodbye' => 'au revoir',
-        );
+        $expected = ['key.say_goodbye' => 'au revoir'];
         $this->assertEquals($expected, $result);
     }
 
     protected function assertSameTransUnit($expected, $result)
     {
-        $this->assertEquals(count($expected), count($result));
+        $this->assertEquals(is_countable($expected) ? count($expected) : 0, is_countable($result) ? count($result) : 0);
 
         foreach ($expected as $i => $transUnit) {
             $this->assertEquals($transUnit['id'], $result[$i]['id']);
             $this->assertEquals($transUnit['key'], $result[$i]['key']);
             $this->assertEquals($transUnit['domain'], $result[$i]['domain']);
 
-            $this->assertEquals(count($transUnit['translations']), count($result[$i]['translations']));
+            $this->assertEquals(is_countable($transUnit['translations']) ? count($transUnit['translations']) : 0, is_countable($result[$i]['translations']) ? count($result[$i]['translations']) : 0);
 
             /*
              * $expected has a fixed order. It is unsafe to rely on the order in which

--- a/Tests/Unit/Repository/Propel/FileRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/FileRepositoryTest.php
@@ -22,34 +22,22 @@ class FileRepositoryTest extends BaseUnitTestCase
 
         $repository = new FileRepository($con);
 
-        $result = $repository->findForLocalesAndDomains(array('de'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.de.yml',
-        );
+        $result = $repository->findForLocalesAndDomains(['de'], []);
+        $expected = ['Resources/translations/superTranslations.de.yml'];
         $this->assertEquals(1, count($result));
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array('fr'), array());
-        $expected = array(
-            'Resources/translations/superTranslations.fr.yml',
-            'Resources/translations/messages.fr.yml',
-        );
+        $result = $repository->findForLocalesAndDomains(['fr'], []);
+        $expected = ['Resources/translations/superTranslations.fr.yml', 'Resources/translations/messages.fr.yml'];
         $this->assertEquals(2, count($result));
         $this->assertFilesPath($expected, $result);
 
-        $result = $repository->findForLocalesAndDomains(array(), array('messages'));
-        $expected = array(
-            'Resources/translations/messages.fr.yml',
-            'Resources/translations/messages.en.yml',
-        );
+        $result = $repository->findForLocalesAndDomains([], ['messages']);
+        $expected = ['Resources/translations/messages.fr.yml', 'Resources/translations/messages.en.yml'];
         $this->assertEquals(2, count($result));
 
-        $result = $repository->findForLocalesAndDomains(array('en', 'de'), array('messages', 'superTranslations'));
-        $expected = array(
-            'Resources/translations/superTranslations.en.yml',
-            'Resources/translations/superTranslations.de.yml',
-            'Resources/translations/messages.en.yml',
-        );
+        $result = $repository->findForLocalesAndDomains(['en', 'de'], ['messages', 'superTranslations']);
+        $expected = ['Resources/translations/superTranslations.en.yml', 'Resources/translations/superTranslations.de.yml', 'Resources/translations/messages.en.yml'];
         $this->assertEquals(3, count($result));
         $this->assertFilesPath($expected, $result);
     }

--- a/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
+++ b/Tests/Unit/Repository/Propel/TransUnitRepositoryTest.php
@@ -95,7 +95,7 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
         $con = $this->loadDatabase();
         $repository = new TransUnitRepository($con);
 
-        $count = call_user_func_array([$repository, 'count'], $arguments);
+        $count = call_user_func_array($repository->count(...), $arguments);
 
         $this->assertEquals($expectedCount, $count);
     }
@@ -291,14 +291,14 @@ class TransUnitRepositoryTest extends BaseUnitTestCase
 
     protected function assertSameTransUnit($expected, $result)
     {
-        $this->assertEquals(count($expected), count($result));
+        $this->assertEquals(is_countable($expected) ? count($expected) : 0, is_countable($result) ? count($result) : 0);
 
         foreach ($expected as $i => $transUnit) {
             $this->assertEquals($transUnit['id'], $result[$i]['id']);
             $this->assertEquals($transUnit['key'], $result[$i]['key']);
             $this->assertEquals($transUnit['domain'], $result[$i]['domain']);
 
-            $this->assertEquals(count($transUnit['translations']), count($result[$i]['translations']));
+            $this->assertEquals(is_countable($transUnit['translations']) ? count($transUnit['translations']) : 0, is_countable($result[$i]['translations']) ? count($result[$i]['translations']) : 0);
 
             foreach ($transUnit['translations'] as $j => $translation) {
                 $this->assertEquals($translation['locale'], $result[$i]['translations'][$j]['locale']);

--- a/Tests/Unit/Translation/Exporter/JsonExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/JsonExporterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class JsonExporterTest extends TestCase
 {
-    private $outFileName = '/file.out';
+    private string $outFileName = '/file.out';
 
     public function tearDown(): void
     {
@@ -31,18 +31,14 @@ class JsonExporterTest extends TestCase
         $exporter = new JsonExporter();
 
         // export empty array
-        $exporter->export($outFile, array());
+        $exporter->export($outFile, []);
         $expectedContent = <<<C
 []
 C;
         $this->assertJsonStringEqualsJsonFile($outFile, $expectedContent);
 
         // export array with values
-        $exporter->export($outFile, array(
-            'key.a' => 'aaa',
-            'key.b' => 'bbb',
-            'key.c' => 'ccc',
-        ));
+        $exporter->export($outFile, ['key.a' => 'aaa', 'key.b' => 'bbb', 'key.c' => 'ccc']);
         $expectedContent = <<<EOL
 {
     "key.a": "aaa",

--- a/Tests/Unit/Translation/Exporter/PhpExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/PhpExporterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PhpExporterTest extends TestCase
 {
-    private $outFileName = '/file.out';
+    private string $outFileName = '/file.out';
 
     public function tearDown(): void
     {
@@ -33,7 +33,7 @@ class PhpExporterTest extends TestCase
         $exporter = new PhpExporter();
 
         // export empty array
-        $exporter->export($outFile, array());
+        $exporter->export($outFile, []);
         $expectedContent = <<<C
 <?php
 return array (
@@ -42,11 +42,7 @@ C;
         $this->assertEquals($expectedContent, file_get_contents($outFile));
 
         // export array with values
-        $exporter->export($outFile, array(
-            'key.a' => 'aaa',
-            'key.b' => 'bbb',
-            'key.c' => 'ccc',
-        ));
+        $exporter->export($outFile, ['key.a' => 'aaa', 'key.b' => 'bbb', 'key.c' => 'ccc']);
         $expectedContent = <<<C
 <?php
 return array (

--- a/Tests/Unit/Translation/Exporter/XliffExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/XliffExporterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class XliffExporterTest extends TestCase
 {
-    private $outFileName = '/file.en.out';
+    private string $outFileName = '/file.en.out';
 
     public function tearDown(): void
     {
@@ -33,7 +33,7 @@ class XliffExporterTest extends TestCase
         $exporter = new XliffExporter();
 
         // export empty array
-        $exporter->export($outFile, array());
+        $exporter->export($outFile, []);
         $expectedContent = <<<C
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
@@ -56,12 +56,8 @@ C;
         $exporter = new XliffExporter();
 
         // export array with values
-        $exporter->export($outFile, array(
-            'key.a' => 'aaa',
-            'key.b' => 'bbb',
-            'key.c' => 'ccc',
-        ));
-        $expectedContent = <<<C
+        $exporter->export($outFile, ['key.a' => 'aaa', 'key.b' => 'bbb', 'key.c' => 'ccc']);
+        $expectedContent = <<<C_WRAP
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" datatype="plaintext" original="file.ext" target-language="en">
@@ -82,7 +78,7 @@ C;
   </file>
 </xliff>
 
-C;
+C_WRAP;
         $this->assertXmlStringEqualsXmlFile($outFile, $expectedContent);
     }
 }

--- a/Tests/Unit/Translation/Exporter/YamlExporterTest.php
+++ b/Tests/Unit/Translation/Exporter/YamlExporterTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class YamlExporterTest extends TestCase
 {
-    private $outFileName = '/file.out';
+    private string $outFileName = '/file.out';
 
     public function tearDown(): void
     {
@@ -33,16 +33,12 @@ class YamlExporterTest extends TestCase
         $exporter = new YamlExporter();
 
         // export empty array
-        $exporter->export($outFile, array());
+        $exporter->export($outFile, []);
         $expectedContent = '{  }';
         $this->assertEquals($expectedContent, trim(file_get_contents($outFile)));
 
         // export array with values
-        $exporter->export($outFile, array(
-            'key.a' => 'aaa',
-            'key.b' => 'bbb',
-            'key.c' => 'ccc',
-        ));
+        $exporter->export($outFile, ['key.a' => 'aaa', 'key.b' => 'bbb', 'key.c' => 'ccc']);
         $expectedContent = <<<C
 key.a: aaa
 key.b: bbb
@@ -58,18 +54,12 @@ C;
     {
         $exporter = new TmpExporter();
 
-        $result = $exporter->createMultiArray(array('foo.bar.baz' => 'foobar'));
-        $expected = array('foo' => array('bar' => array('baz' => 'foobar')));
+        $result = $exporter->createMultiArray(['foo.bar.baz' => 'foobar']);
+        $expected = ['foo' => ['bar' => ['baz' => 'foobar']]];
         $this->assertEquals($expected, $result);
 
-        $result = $exporter->createMultiArray(array(
-                'foo.bar.baz' => 'foobar',
-                'foo.foobaz' => 'bazbar',
-            ));
-        $expected = array('foo' => array(
-            'foobaz' => 'bazbar',
-            'bar'   => array('baz' => 'foobar'),
-        ));
+        $result = $exporter->createMultiArray(['foo.bar.baz' => 'foobar', 'foo.foobaz' => 'bazbar']);
+        $expected = ['foo' => ['foobaz' => 'bazbar', 'bar'   => ['baz' => 'foobar']]];
         $this->assertEquals($expected, $result);
     }
 
@@ -80,44 +70,20 @@ C;
     {
         $exporter = new TmpExporter();
 
-        $result = $exporter->flattenArray(array('foo' => array('bar' => array('baz' => 'foobar'))));
-        $expected = array('foo.bar.baz' => 'foobar');
+        $result = $exporter->flattenArray(['foo' => ['bar' => ['baz' => 'foobar']]]);
+        $expected = ['foo.bar.baz' => 'foobar'];
         $this->assertEquals($expected, $result);
 
         $result = $exporter->flattenArray(
-            array('bundle' => array('foo' => array(
-                        'foobaz' => 'bazbar',
-                        'bar'   => array(
-                                'baz0' => 'foobar',
-                                'baz1' => 'foobaz',
-                            ),
-                    ),
-                ),
-            )
+            ['bundle' => ['foo' => ['foobaz' => 'bazbar', 'bar'   => ['baz0' => 'foobar', 'baz1' => 'foobaz']]]]
         );
-        $expected = array('bundle.foo' => array(
-                'foobaz' => 'bazbar',
-                'bar'   => array(
-                        'baz0' => 'foobar',
-                        'baz1' => 'foobaz',
-                    ),
-            ),
-        );
+        $expected = ['bundle.foo' => ['foobaz' => 'bazbar', 'bar'   => ['baz0' => 'foobar', 'baz1' => 'foobaz']]];
         $this->assertEquals($expected, $result);
 
         $result = $exporter->flattenArray(
-            array('bundle' => array('foo' => array(
-                        'foobaz' => 'bazbar',
-                        'bar'   => array('baz' => 'foobar'),
-                    ),
-                ),
-            )
+            ['bundle' => ['foo' => ['foobaz' => 'bazbar', 'bar'   => ['baz' => 'foobar']]]]
         );
-        $expected = array('bundle.foo' => array(
-                'foobaz' => 'bazbar',
-                'bar'   => array('baz' => 'foobar'),
-            ),
-        );
+        $expected = ['bundle.foo' => ['foobaz' => 'bazbar', 'bar'   => ['baz' => 'foobar']]];
         $this->assertEquals($expected, $result);
     }
 }

--- a/Tests/Unit/Translation/Importer/FileImporterTest.php
+++ b/Tests/Unit/Translation/Importer/FileImporterTest.php
@@ -25,10 +25,7 @@ class FileImporterTest extends BaseUnitTestCase
         $em = $this->getMockSqliteEntityManager();
         $this->createSchema($em);
 
-        $loaders = array(
-            'yml' => new YamlFileLoader(),
-            'php' => new PhpFileLoader(),
-        );
+        $loaders = ['yml' => new YamlFileLoader(), 'php' => new PhpFileLoader()];
 
         $storage = $this->getORMStorage($em);
 
@@ -40,10 +37,7 @@ class FileImporterTest extends BaseUnitTestCase
         $this->assertDatabaseEntries($em, 0);
 
         // import files
-        $files = array(
-            new SplFileInfo(__DIR__.'/../../../Fixtures/test.en.yml', '', ''),
-            new SplFileInfo(__DIR__.'/../../../Fixtures/test.fr.php', '', ''),
-        );
+        $files = [new SplFileInfo(__DIR__.'/../../../Fixtures/test.en.yml', '', ''), new SplFileInfo(__DIR__.'/../../../Fixtures/test.fr.php', '', '')];
 
         foreach ($files as $file) {
             $importer->import($file);

--- a/Tests/Unit/Translation/Loader/DatabaseLoaderTest.php
+++ b/Tests/Unit/Translation/Loader/DatabaseLoaderTest.php
@@ -4,6 +4,7 @@ namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Translation\Loader;
 
 use Lexik\Bundle\TranslationBundle\Translation\Loader\DatabaseLoader;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
+use Symfony\Component\Translation\MessageCatalogue;
 
 /**
  * DatabaseLoader tests.
@@ -21,31 +22,22 @@ class DatabaseLoaderTest extends BaseUnitTestCase
         $this->createSchema($em);
         $this->loadFixtures($em);
 
-        $loader = new DatabaseLoader($this->getORMStorage($em), 'Lexik\\Bundle\\TranslationBundle\\Entity\\TransUnit');
+        $loader = new DatabaseLoader($this->getORMStorage($em), \Lexik\Bundle\TranslationBundle\Entity\TransUnit::class);
 
         $catalogue = $loader->load(null, 'it');
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $catalogue);
-        $this->assertEquals(array(), $catalogue->all());
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
+        $this->assertEquals([], $catalogue->all());
         $this->assertEquals('it', $catalogue->getLocale());
 
         $catalogue = $loader->load(null, 'fr');
-        $expectedTranslations = array(
-            'messages' => array(
-                'key.say_goodbye' => 'au revoir',
-                'key.say_wtf'     => 'c\'est quoi ce bordel !?!',
-            ),
-        );
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $catalogue);
+        $expectedTranslations = ['messages' => ['key.say_goodbye' => 'au revoir', 'key.say_wtf'     => 'c\'est quoi ce bordel !?!']];
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
         $this->assertEquals($expectedTranslations, $catalogue->all());
         $this->assertEquals('fr', $catalogue->getLocale());
 
         $catalogue = $loader->load(null, 'en', 'superTranslations');
-        $expectedTranslations = array(
-            'superTranslations' => array(
-                'key.say_hello' => 'hello',
-            ),
-        );
-        $this->assertInstanceOf('Symfony\Component\Translation\MessageCatalogue', $catalogue);
+        $expectedTranslations = ['superTranslations' => ['key.say_hello' => 'hello']];
+        $this->assertInstanceOf(MessageCatalogue::class, $catalogue);
         $this->assertEquals($expectedTranslations, $catalogue->all());
         $this->assertEquals('en', $catalogue->getLocale());
     }

--- a/Tests/Unit/Translation/Manager/FileManagerTest.php
+++ b/Tests/Unit/Translation/Manager/FileManagerTest.php
@@ -2,9 +2,13 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Translation\Manager;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork as ODMUnitOfWork;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork as ORMUnitOfWork;
 use Lexik\Bundle\TranslationBundle\Manager\FileManager;
+use Lexik\Bundle\TranslationBundle\Storage\DoctrineMongoDBStorage;
+use Lexik\Bundle\TranslationBundle\Storage\DoctrineORMStorage;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
 
@@ -15,25 +19,13 @@ use Lexik\Bundle\TranslationBundle\Propel\FileQuery;
  */
 class FileManagerTest extends BaseUnitTestCase
 {
-    /**
-     * @var \Doctrine\ORM\EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var \Doctrine\ODM\MongoDB\DocumentManager
-     */
-    private $dm;
+    private DocumentManager $dm;
 
-    /**
-     * @var \Lexik\Bundle\TranslationBundle\Storage\DoctrineORMStorage
-     */
-    private $ormStorage;
+    private DoctrineORMStorage $ormStorage;
 
-    /**
-     * @var \Lexik\Bundle\TranslationBundle\Storage\DoctrineMongoDBStorage
-     */
-    private $odmStorage;
+    private DoctrineMongoDBStorage $odmStorage;
 
     /**
      *
@@ -41,10 +33,7 @@ class FileManagerTest extends BaseUnitTestCase
      */
     private $propelStorage;
 
-    /**
-     * @var string
-     */
-    private $rootDir = '/test/root/dir/app';
+    private string $rootDir = '/test/root/dir/app';
 
     public function setUp(): void
     {

--- a/Tests/Unit/Translation/Manager/TransUnitManagerTest.php
+++ b/Tests/Unit/Translation/Manager/TransUnitManagerTest.php
@@ -6,6 +6,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\UnitOfWork as ODMUnitOfWork;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork as ORMUnitOfWork;
+use Lexik\Bundle\TranslationBundle\Entity\TransUnit;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitManager;
 use Lexik\Bundle\TranslationBundle\Manager\FileManager;
 use Lexik\Bundle\TranslationBundle\Storage\DoctrineMongoDBStorage;
@@ -20,36 +21,17 @@ use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
  */
 class TransUnitManagerTest extends BaseUnitTestCase
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private EntityManager $em;
 
-    /**
-     * @var DocumentManager
-     */
-    private $dm;
+    private DocumentManager $dm;
 
-    /**
-     * @var DoctrineORMStorage
-     */
-    private $ormStorage;
+    private DoctrineORMStorage $ormStorage;
 
-    /**
-     * @var DoctrineMongoDBStorage
-     */
-    private $odmStorage;
+    private DoctrineMongoDBStorage $odmStorage;
 
-    /**
-     *
-     * @var PropelStorage
-     */
-    private $propelStorage;
+    private PropelStorage $propelStorage;
 
-    /**
-     * @var string
-     */
-    private $rootDir = '/test/root/dir/app';
+    private string $rootDir = '/test/root/dir/app';
 
     public function setUp(): void
     {
@@ -132,7 +114,7 @@ class TransUnitManagerTest extends BaseUnitTestCase
         $fileManager = new FileManager($this->ormStorage, self::ENTITY_FILE_CLASS, $this->rootDir);
         $manager = new TransUnitManager($this->ormStorage, $fileManager, $this->rootDir);
 
-        $class = 'Lexik\Bundle\TranslationBundle\Entity\TransUnit';
+        $class = TransUnit::class;
         $transUnit = $manager->create('bwah', 'messages', true);
 
         $translation = $manager->addTranslation($transUnit, 'en', 'bwaaaAaAahhHHh', null, true);
@@ -280,7 +262,7 @@ class TransUnitManagerTest extends BaseUnitTestCase
         $this->assertEquals(ORMUnitOfWork::STATE_NEW, $this->em->getUnitOfWork()->getEntityState($transUnit));
         $this->assertEquals(0, $transUnit->getTranslations()->count());
 
-        $transUnit = $manager->newInstance(array('fr', 'en'));
+        $transUnit = $manager->newInstance(['fr', 'en']);
         $this->assertEquals(ORMUnitOfWork::STATE_NEW, $this->em->getUnitOfWork()->getEntityState($transUnit));
         $this->assertEquals('fr', $transUnit->getTranslations()->get(0)->getLocale());
         $this->assertEquals('en', $transUnit->getTranslations()->get(1)->getLocale());
@@ -298,7 +280,7 @@ class TransUnitManagerTest extends BaseUnitTestCase
         $this->assertEquals(ORMUnitOfWork::STATE_NEW, $this->dm->getUnitOfWork()->getDocumentState($transUnit));
         $this->assertEquals(0, $transUnit->getTranslations()->count());
 
-        $transUnit = $manager->newInstance(array('fr', 'en'));
+        $transUnit = $manager->newInstance(['fr', 'en']);
         $this->assertEquals(ORMUnitOfWork::STATE_NEW, $this->dm->getUnitOfWork()->getDocumentState($transUnit));
         $this->assertEquals('fr', $transUnit->getTranslations()->get(0)->getLocale());
         $this->assertEquals('en', $transUnit->getTranslations()->get(1)->getLocale());
@@ -316,7 +298,7 @@ class TransUnitManagerTest extends BaseUnitTestCase
         $this->assertTrue($transUnit->isNew());
         $this->assertEquals(0, $transUnit->getTranslations()->count());
 
-        $transUnit = $manager->newInstance(array('fr', 'en'));
+        $transUnit = $manager->newInstance(['fr', 'en']);
         $this->assertTrue($transUnit->isNew());
         $this->assertEquals('fr', $transUnit->getTranslations()->get(0)->getLocale());
         $this->assertEquals('en', $transUnit->getTranslations()->get(1)->getLocale());

--- a/Tests/Unit/Translation/TranslatorTest.php
+++ b/Tests/Unit/Translation/TranslatorTest.php
@@ -34,19 +34,7 @@ class TranslatorTest extends BaseUnitTestCase
         $translator = $this->createTranslator($em, sys_get_temp_dir());
         $translator->addDatabaseResources();
 
-        $expected = array(
-            'de' => array(
-                array('database', 'DB', 'superTranslations'),
-            ),
-            'en' => array(
-                array('database', 'DB', 'messages'),
-                array('database', 'DB', 'superTranslations'),
-            ),
-            'fr' => array(
-                array('database', 'DB', 'messages'),
-                array('database', 'DB', 'superTranslations'),
-            ),
-        );
+        $expected = ['de' => [['database', 'DB', 'superTranslations']], 'en' => [['database', 'DB', 'messages'], ['database', 'DB', 'superTranslations']], 'fr' => [['database', 'DB', 'messages'], ['database', 'DB', 'superTranslations']]];
         $this->assertEquals($expected, $translator->dbResources);
     }
 
@@ -98,7 +86,7 @@ class TranslatorTest extends BaseUnitTestCase
         $this->assertTrue(file_exists($cacheDir.'/catalogue.en.php'));
         $this->assertTrue(file_exists($cacheDir.'/catalogue.en.php.meta'));
 
-        $translator->removeLocalesCacheFiles(array('fr', 'en'));
+        $translator->removeLocalesCacheFiles(['fr', 'en']);
 
         $this->assertFalse(file_exists($cacheDir.'/database.resources.php'));
         $this->assertFalse(file_exists($cacheDir.'/database.resources.php.meta'));
@@ -117,7 +105,7 @@ class TranslatorTest extends BaseUnitTestCase
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(
             GetDatabaseResourcesEvent::class,
-            array($listener, 'onGetDatabaseResources')
+            $listener->onGetDatabaseResources(...)
         );
 
         $container = new Container();
@@ -125,10 +113,8 @@ class TranslatorTest extends BaseUnitTestCase
         $container->set('event_dispatcher', $dispatcher);
         $container->compile();
 
-        $loaderIds = array();
-        $options = array(
-            'cache_dir' => $cacheDir,
-        );
+        $loaderIds = [];
+        $options = ['cache_dir' => $cacheDir];
 
         return new TranslatorMock($container, new MessageFormatter(), 'en', $loaderIds, $options);
     }
@@ -155,12 +141,12 @@ class TranslatorTest extends BaseUnitTestCase
 
 class TranslatorMock extends Translator
 {
-    public $dbResources = array();
+    public $dbResources = [];
 
     public function addResource($format, $resource, $locale, $domain = 'messages')
     {
         if ('database' == $format) {
-            $this->dbResources[$locale][] = array($format, $resource, $domain);
+            $this->dbResources[$locale][] = [$format, $resource, $domain];
         }
 
         parent::addResource($format, $resource, $locale, $domain);

--- a/Tests/Unit/Util/DataGrid/DataGridFormatterTest.php
+++ b/Tests/Unit/Util/DataGrid/DataGridFormatterTest.php
@@ -17,53 +17,12 @@ class DataGridFormatterTest extends BaseUnitTestCase
      */
     public function testCreateListResponse()
     {
-        $datas = array(
-            array('id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'au revoir'),
-                array('locale' => 'en', 'content' => 'good bye'),
-            )),
-            array('id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'salut'),
-                array('locale' => 'de', 'content' => 'heil'),
-            )),
-            array('id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => array(
-                array('locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'),
-                array('locale' => 'xx', 'content' => 'xxx xxx xxx'),
-            )),
-        );
+        $datas = [['id' => 2, 'key' => 'key.say_goodbye', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'au revoir'], ['locale' => 'en', 'content' => 'good bye']]], ['id' => 1, 'key' => 'key.say_hello', 'domain' => 'superTranslations', 'translations' => [['locale' => 'fr', 'content' => 'salut'], ['locale' => 'de', 'content' => 'heil']]], ['id' => 3, 'key' => 'key.say_wtf', 'domain' => 'messages', 'translations' => [['locale' => 'fr', 'content' => 'c\'est quoi ce bordel !?!'], ['locale' => 'xx', 'content' => 'xxx xxx xxx']]]];
         $total = 3;
 
-        $expected = array(
-            'translations' => array(
-                array(
-                    '_id'     => 2,
-                    '_domain' => 'messages',
-                    '_key'    => 'key.say_goodbye',
-                    'de'      => '',
-                    'en'      => 'good bye',
-                    'fr'      => 'au revoir',
-                ),
-                array(
-                    '_id'     => 1,
-                    '_domain' => 'superTranslations',
-                    '_key'    => 'key.say_hello',
-                    'de'      => 'heil',
-                    'en'      => '',
-                    'fr'      => 'salut',
-                ),
-                array(
-                    '_id'     => 3,
-                    '_domain' => 'messages',
-                    '_key'    => 'key.say_wtf',
-                    'de'      => '',
-                    'en'      => '',
-                    'fr'      => 'c\'est quoi ce bordel !?!',
-                ),
-            ),
-            'total' => 3,
-        );
+        $expected = ['translations' => [['_id'     => 2, '_domain' => 'messages', '_key'    => 'key.say_goodbye', 'de'      => '', 'en'      => 'good bye', 'fr'      => 'au revoir'], ['_id'     => 1, '_domain' => 'superTranslations', '_key'    => 'key.say_hello', 'de'      => 'heil', 'en'      => '', 'fr'      => 'salut'], ['_id'     => 3, '_domain' => 'messages', '_key'    => 'key.say_wtf', 'de'      => '', 'en'      => '', 'fr'      => 'c\'est quoi ce bordel !?!']], 'total' => 3];
 
-        $formatter = new DataGridFormatter(new LocaleManager(array('de', 'en', 'fr')), StorageInterface::STORAGE_ORM);
+        $formatter = new DataGridFormatter(new LocaleManager(['de', 'en', 'fr']), StorageInterface::STORAGE_ORM);
         $this->assertEquals(json_encode($expected, JSON_HEX_APOS), $formatter->createListResponse($datas, $total)->getContent());
     }
 }

--- a/Tests/Unit/Util/DataGrid/DataGridRequestHandlerTest.php
+++ b/Tests/Unit/Util/DataGrid/DataGridRequestHandlerTest.php
@@ -20,13 +20,9 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
         $method = $this->getReflectionMethod('filterTokenTranslations');
         $handler = $this->getDataGridRequestHandler();
 
-        $result = $method->invokeArgs($handler, array(
-            array(),
-            0,
-            array('rows' => 20, 'page' => 1)
-        ));
+        $result = $method->invokeArgs($handler, [[], 0, ['rows' => 20, 'page' => 1]]);
 
-        $this->assertEquals(array(array(), 0), $result);
+        $this->assertEquals([[], 0], $result);
     }
 
     /**
@@ -43,33 +39,25 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
         $method = $this->getReflectionMethod('filterTokenTranslations');
         $handler = $this->getDataGridRequestHandler();
 
-        $transUnits = array();
+        $transUnits = [];
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_hello', 'superTranslations');
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_goodbye', 'messages');
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_wtf', 'messages');
 
         // 20 rows -> all in one page
-        list($result, $count) = $method->invokeArgs($handler, array(
-            $transUnits,
-            count($transUnits),
-            array('rows' => 20, 'page' => 1)
-        ));
+        [$result, $count] = $method->invokeArgs($handler, [$transUnits, count($transUnits), ['rows' => 20, 'page' => 1]]);
 
         $this->assertEquals(3, $count);
-        $this->assertEquals(3, count($result));
+        $this->assertEquals(3, is_countable($result) ? count($result) : 0);
         $this->assertEquals('key.say_hello', $result[0]->getKey());
         $this->assertEquals('key.say_goodbye', $result[1]->getKey());
         $this->assertEquals('key.say_wtf', $result[2]->getKey());
 
         // only 2 rows -> 2 pages
-        list($result, $count) = $method->invokeArgs($handler, array(
-            $transUnits,
-            count($transUnits),
-            array('rows' => 2, 'page' => 2)
-        ));
+        [$result, $count] = $method->invokeArgs($handler, [$transUnits, count($transUnits), ['rows' => 2, 'page' => 2]]);
 
         $this->assertEquals(3, $count);
-        $this->assertEquals(1, count($result));
+        $this->assertEquals(1, is_countable($result) ? count($result) : 0);
         $this->assertEquals('key.say_wtf', $result[0]->getKey());
     }
 
@@ -87,32 +75,24 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
         $method = $this->getReflectionMethod('filterTokenTranslations');
         $handler = $this->getDataGridRequestHandler();
 
-        $transUnits = array();
+        $transUnits = [];
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_hello', 'superTranslations');
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_goodbye', 'messages');
         $transUnits[] = $ormStorage->getTransUnitByKeyAndDomain('key.say_wtf', 'messages');
 
         // filter by domain
-        list($result, $count) = $method->invokeArgs($handler, array(
-            $transUnits,
-            count($transUnits),
-            array('rows' => 20, 'page' => 1, '_search' => true, 'domain' => 'mess')
-        ));
+        [$result, $count] = $method->invokeArgs($handler, [$transUnits, count($transUnits), ['rows' => 20, 'page' => 1, '_search' => true, 'domain' => 'mess']]);
 
         $this->assertEquals(2, $count);
-        $this->assertEquals(2, count($result));
+        $this->assertEquals(2, is_countable($result) ? count($result) : 0);
         $this->assertEquals('key.say_goodbye', $result[0]->getKey());
         $this->assertEquals('key.say_wtf', $result[1]->getKey());
 
         // filter by domain and locale en
-        list($result, $count) = $method->invokeArgs($handler, array(
-            $transUnits,
-            count($transUnits),
-            array('rows' => 20, 'page' => 1, '_search' => true, 'domain' => 'mess', 'en' => 'the fu')
-        ));
+        [$result, $count] = $method->invokeArgs($handler, [$transUnits, count($transUnits), ['rows' => 20, 'page' => 1, '_search' => true, 'domain' => 'mess', 'en' => 'the fu']]);
 
         $this->assertEquals(1, $count);
-        $this->assertEquals(1, count($result));
+        $this->assertEquals(1, is_countable($result) ? count($result) : 0);
         $this->assertEquals('key.say_wtf', $result[0]->getKey());
     }
 
@@ -125,26 +105,20 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
         $handler = $this->getDataGridRequestHandler();
 
         // no params
-        $result = $method->invokeArgs($handler, array(
-            array(),
-        ));
+        $result = $method->invokeArgs($handler, [[]]);
 
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
 
         // page and rows
-        $result = $method->invokeArgs($handler, array(
-            array('page' => 1, 'rows' => 10),
-        ));
+        $result = $method->invokeArgs($handler, [['page' => 1, 'rows' => 10]]);
 
-        $this->assertEquals(array('page' => 1, 'rows' => 10), $result);
+        $this->assertEquals(['page' => 1, 'rows' => 10], $result);
 
         // page and rows + filters
-        $result = $method->invokeArgs($handler, array(
-            array('page' => 1, 'rows' => 10, '_search' => true, '_domain' => 'super', '_en' => 'man'),
-        ));
+        $result = $method->invokeArgs($handler, [['page' => 1, 'rows' => 10, '_search' => true, '_domain' => 'super', '_en' => 'man']]);
 
         $this->assertEquals(
-            array('page' => 1, 'rows' => 10, '_search' => true, 'domain' => 'super', 'en' => 'man'),
+            ['page' => 1, 'rows' => 10, '_search' => true, 'domain' => 'super', 'en' => 'man'],
             $result
         );
     }
@@ -154,7 +128,7 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
      */
     private function getReflectionMethod($name)
     {
-        $class = new \ReflectionClass('Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridRequestHandler');
+        $class = new \ReflectionClass(\Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridRequestHandler::class);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
 
@@ -166,19 +140,19 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
      */
     private function getDataGridRequestHandler()
     {
-        $transUnitManagerMock = $this->getMockBuilder('Lexik\Bundle\TranslationBundle\Manager\TransUnitManager')
+        $transUnitManagerMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Manager\TransUnitManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $fileManagerMock = $this->getMockBuilder('Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface')
+        $fileManagerMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $storageMock = $this->getMockBuilder('Lexik\Bundle\TranslationBundle\Storage\StorageInterface')
+        $storageMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Storage\StorageInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $localeManager = new LocaleManager(array());
+        $localeManager = new LocaleManager([]);
 
         return new DataGridRequestHandler($transUnitManagerMock, $fileManagerMock, $storageMock, $localeManager);
     }

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -80,12 +80,12 @@ class AppKernel extends Kernel
 
     public function serialize()
     {
-        return serialize(array($this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()));
+        return serialize([$this->testCase, $this->rootConfig, $this->getEnvironment(), $this->isDebug()]);
     }
 
     public function unserialize($str)
     {
-        call_user_func_array(array($this, '__construct'), unserialize($str));
+        call_user_func_array([$this, '__construct'], unserialize($str));
     }
 
     protected function getKernelParameters(): array

--- a/Tests/app/test/bundles.php
+++ b/Tests/app/test/bundles.php
@@ -1,7 +1,11 @@
 <?php
 
-return array(
-    new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-    new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-    new \Lexik\Bundle\TranslationBundle\LexikTranslationBundle(),
-);
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Lexik\Bundle\TranslationBundle\LexikTranslationBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+    new DoctrineBundle(),
+    new LexikTranslationBundle(),
+];

--- a/Tests/app/test/database.php
+++ b/Tests/app/test/database.php
@@ -3,27 +3,7 @@
 if (ORM_TYPE == "doctrine") {
     $container->loadFromExtension(
         'doctrine',
-        array(
-            'orm'  => array(
-                'mappings' => array(
-                    'Mapping' => array(
-                        'type'      => 'xml',
-                        'prefix'    => 'Lexik\Bundle\TranslationBundle\Entity',
-                        'is_bundle' => false,
-                        'dir'       => '%kernel.project_dir%/Resources/config/doctrine',
-                    ),
-                ),
-            ),
-            'dbal' => array(
-                'charset'  => 'UTF8',
-                'driver'   => DB_ENGINE,
-                'host'     => DB_HOST,
-                'port'     => DB_PORT,
-                'dbname'   => DB_NAME,
-                'user'     => DB_USER,
-                'password' => DB_PASSWD,
-            ),
-        )
+        ['orm'  => ['mappings' => ['Mapping' => ['type'      => 'xml', 'prefix'    => 'Lexik\Bundle\TranslationBundle\Entity', 'is_bundle' => false, 'dir'       => '%kernel.project_dir%/Resources/config/doctrine']]], 'dbal' => ['charset'  => 'UTF8', 'driver'   => DB_ENGINE, 'host'     => DB_HOST, 'port'     => DB_PORT, 'dbname'   => DB_NAME, 'user'     => DB_USER, 'password' => DB_PASSWD]]
     );
 } else {
     throw new Exception("Currently only doctrine is supported");

--- a/Translation/DatabaseFreshResource.php
+++ b/Translation/DatabaseFreshResource.php
@@ -9,33 +9,19 @@ use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
  *
  * @author Cédric Girard <c.girard@lexik.fr>
  */
-class DatabaseFreshResource implements SelfCheckingResourceInterface
+class DatabaseFreshResource implements SelfCheckingResourceInterface, \Stringable
 {
-    /**
-     * @var string
-     */
-    private $locale;
 
-    /**
-     * @var string
-     */
-    private $domain;
-
-    /**
-     *
-     * @param string $locale
-     * @param string $domain
-     */
-    public function __construct($locale, $domain)
-    {
-        $this->locale = $locale;
-        $this->domain = $domain;
+    public function __construct(
+        private readonly string $locale,
+        private readonly string $domain,
+    ) {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getResource();
     }

--- a/Translation/Exporter/ExporterCollector.php
+++ b/Translation/Exporter/ExporterCollector.php
@@ -25,7 +25,6 @@ class ExporterCollector
     /**
      *
      * @param string $id
-     * @param ExporterInterface $exporter
      */
     public function addExporter($id, ExporterInterface $exporter)
     {

--- a/Translation/Exporter/JsonExporter.php
+++ b/Translation/Exporter/JsonExporter.php
@@ -10,16 +10,11 @@ namespace Lexik\Bundle\TranslationBundle\Translation\Exporter;
 class JsonExporter implements ExporterInterface
 {
     /**
-     * @var bool
-     */
-    private $hierarchicalFormat;
-
-    /**
      * @param bool $hierarchicalFormat
      */
-    public function __construct($hierarchicalFormat = false)
-    {
-        $this->hierarchicalFormat = $hierarchicalFormat;
+    public function __construct(
+        private $hierarchicalFormat = false
+    ) {
     }
 
     /**
@@ -41,12 +36,11 @@ class JsonExporter implements ExporterInterface
     }
 
     /**
-     * @param array $translations
      * @return array
      */
     protected function hierarchicalFormat(array $translations)
     {
-        $output = array();
+        $output = [];
         foreach ($translations as $key => $value) {
             $output = array_merge_recursive($output, $this->converterKeyToArray($key, $value));
         }
@@ -56,10 +50,9 @@ class JsonExporter implements ExporterInterface
 
     /**
      * @param string $key
-     * @param mixed  $value
      * @return array
      */
-    protected function converterKeyToArray($key, $value)
+    protected function converterKeyToArray($key, mixed $value)
     {
         $keysTrad = preg_split("/\./", $key);
 
@@ -67,23 +60,19 @@ class JsonExporter implements ExporterInterface
     }
 
     /**
-     * @param mixed $arrayIn
-     * @param mixed $endValue
      * @return array
      */
-    protected function convertArrayToArborescence($arrayIn, $endValue)
+    protected function convertArrayToArborescence(mixed $arrayIn, mixed $endValue)
     {
-        $lenArray = count($arrayIn);
+        $lenArray = is_countable($arrayIn) ? count($arrayIn) : 0;
 
         if ($lenArray == 0) {
             return $endValue;
         }
-
-        reset($arrayIn);
-        $firstKey = key($arrayIn);
+        $firstKey = array_key_first($arrayIn);
         $firstValue = $arrayIn[$firstKey];
         unset($arrayIn[$firstKey]);
 
-        return array($firstValue => $this->convertArrayToArborescence($arrayIn, $endValue));
+        return [$firstValue => $this->convertArrayToArborescence($arrayIn, $endValue)];
     }
 }

--- a/Translation/Exporter/XliffExporter.php
+++ b/Translation/Exporter/XliffExporter.php
@@ -60,7 +60,6 @@ class XliffExporter implements ExporterInterface
     /**
      * Add root nodes to a document.
      *
-     * @param \DOMDocument $dom
      * @param string|null $targetLanguage
      * @return \DOMElement
      */
@@ -87,7 +86,6 @@ class XliffExporter implements ExporterInterface
     /**
      * Create a new trans-unit node.
      *
-     * @param \DOMDocument $dom
      * @param int $id
      * @param string $key
      * @param string $value

--- a/Translation/Exporter/YamlExporter.php
+++ b/Translation/Exporter/YamlExporter.php
@@ -12,14 +12,9 @@ use Symfony\Component\Yaml\Dumper;
  */
 class YamlExporter implements ExporterInterface
 {
-    private $createTree;
-
-    /**
-     * @param bool $createTree
-     */
-    public function __construct($createTree = false)
-    {
-        $this->createTree = $createTree;
+    public function __construct(
+        private bool $createTree = false
+    ) {
     }
 
     /**
@@ -51,7 +46,7 @@ class YamlExporter implements ExporterInterface
      */
     protected function createMultiArray(array $translations)
     {
-        $res = array();
+        $res = [];
 
         foreach ($translations as $keyString => $value) {
             $keys = explode('.', $keyString);
@@ -72,9 +67,7 @@ class YamlExporter implements ExporterInterface
     /**
      *
      *
-     * @param array $array
      * @param $value
-     * @param array $keys
      *
      * @throws \InvalidArgumentException
      */
@@ -90,7 +83,7 @@ class YamlExporter implements ExporterInterface
         }
 
         if (!isset($array[$key])) {
-            $array[$key] = array();
+            $array[$key] = [];
         } elseif (!is_array($array[$key])) {
             //if $array[$key] isset but is not array
             throw new \InvalidArgumentException('Found an leaf, expected a tree');
@@ -102,7 +95,7 @@ class YamlExporter implements ExporterInterface
     /**
      * Make sure we flatten the array in the begnning to make a lower tree
      *
-     * @param mixed $array
+     * @param mixed  $array
      * @param string $prefix
      *
      * @return mixed
@@ -112,7 +105,7 @@ class YamlExporter implements ExporterInterface
         if (is_array($array)) {
             foreach ($array as $key => $subarray) {
                 if (count($array) == 1) {
-                    return $this->flattenArray($subarray, ($prefix == '' ? $prefix : $prefix.'.').$key);
+                    return $this->flattenArray($subarray, ($prefix == '' ? $prefix : $prefix . '.') . $key);
                 }
 
                 $array[$key] = $this->flattenArray($subarray);
@@ -123,7 +116,7 @@ class YamlExporter implements ExporterInterface
             return $array;
         }
 
-        return array($prefix => $array);
+        return [$prefix => $array];
     }
 
     /**

--- a/Translation/Loader/DatabaseLoader.php
+++ b/Translation/Loader/DatabaseLoader.php
@@ -14,18 +14,11 @@ use Symfony\Component\Translation\MessageCatalogue;
 class DatabaseLoader implements LoaderInterface
 {
     /**
-     * @var StorageInterface
-     */
-    private $storage;
-
-    /**
      * Construct.
-     *
-     * @param StorageInterface $storage
      */
-    public function __construct(StorageInterface $storage)
-    {
-        $this->storage = $storage;
+    public function __construct(
+        private readonly StorageInterface $storage,
+    ) {
     }
 
     /**

--- a/Translation/Translator.php
+++ b/Translation/Translator.php
@@ -28,7 +28,7 @@ class Translator extends BaseTranslator
             $this->container->get('event_dispatcher')->dispatch($event);
 
             $resources = $event->getResources();
-            $metadata = array();
+            $metadata = [];
 
             foreach ($resources as $resource) {
                 $metadata[] = new DatabaseFreshResource($resource['locale'], $resource['domain']);
@@ -75,8 +75,6 @@ class Translator extends BaseTranslator
 
     /**
      * Remove the cache file corresponding to each given locale.
-     *
-     * @param array $locales
      */
     public function removeLocalesCacheFiles(array $locales)
     {
@@ -123,7 +121,7 @@ class Translator extends BaseTranslator
      */
     public function getFormats()
     {
-        $allFormats = array();
+        $allFormats = [];
 
         foreach ($this->loaderIds as $id => $formats) {
             foreach ($formats as $format) {

--- a/Util/DataGrid/DataGridFormatter.php
+++ b/Util/DataGrid/DataGridFormatter.php
@@ -13,29 +13,12 @@ use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
 class DataGridFormatter
 {
     /**
-     * Managed locales.
-     *
-     * @var LocaleManagerInterface
-     */
-    protected $localeManager;
-
-    /**
-     * Storage type
-     *
-     * @var string
-     */
-    protected $storage;
-
-    /**
      * Constructor.
      *
-     * @param LocaleManagerInterface  $localeManager
      * @param string $storage
      */
-    public function __construct(LocaleManagerInterface $localeManager, $storage)
+    public function __construct(protected LocaleManagerInterface $localeManager, protected $storage)
     {
-        $this->localeManager = $localeManager;
-        $this->storage = $storage;
     }
 
     /**
@@ -47,19 +30,15 @@ class DataGridFormatter
      */
     public function createListResponse($transUnits, $total)
     {
-        return new JsonResponse(array(
-            'translations' => $this->format($transUnits),
-            'total'        => $total,
-        ));
+        return new JsonResponse(['translations' => $this->format($transUnits), 'total'        => $total]);
     }
 
     /**
      * Returns a JSON response with formatted data.
      *
-     * @param mixed $transUnit
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function createSingleResponse($transUnit)
+    public function createSingleResponse(mixed $transUnit)
     {
         return new JsonResponse($this->formatOne($transUnit));
     }
@@ -72,7 +51,7 @@ class DataGridFormatter
      */
     protected function format($transUnits)
     {
-        $formatted = array();
+        $formatted = [];
 
         foreach ($transUnits as $transUnit) {
             $formatted[] = $this->formatOne($transUnit);
@@ -95,11 +74,7 @@ class DataGridFormatter
             $transUnit['id'] = $transUnit['_id']->{'$id'};
         }
 
-        $formatted = array(
-            '_id'     => $transUnit['id'],
-            '_domain' => $transUnit['domain'],
-            '_key'    => $transUnit['key'],
-        );
+        $formatted = ['_id'     => $transUnit['id'], '_domain' => $transUnit['domain'], '_key'    => $transUnit['key']];
 
         // add locales in the same order as in managed_locales param
         foreach ($this->localeManager->getLocales() as $locale) {
@@ -119,23 +94,14 @@ class DataGridFormatter
     /**
      * Convert a trans unit into an array.
      *
-     * @param TransUnitInterface $transUnit
      * @return array
      */
     protected function toArray(TransUnitInterface $transUnit)
     {
-        $data = array(
-            'id'           => $transUnit->getId(),
-            'domain'       => $transUnit->getDomain(),
-            'key'          => $transUnit->getKey(),
-            'translations' => array(),
-        );
+        $data = ['id'           => $transUnit->getId(), 'domain'       => $transUnit->getDomain(), 'key'          => $transUnit->getKey(), 'translations' => []];
 
         foreach ($transUnit->getTranslations() as $translation) {
-            $data['translations'][] = array(
-                'locale'  => $translation->getLocale(),
-                'content' => $translation->getContent(),
-            );
+            $data['translations'][] = ['locale'  => $translation->getLocale(), 'content' => $translation->getContent()];
         }
 
         return $data;

--- a/Util/Doctrine/SingleColumnArrayHydrator.php
+++ b/Util/Doctrine/SingleColumnArrayHydrator.php
@@ -16,7 +16,7 @@ class SingleColumnArrayHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($data = $this->_stmt->fetch(\PDO::FETCH_NUM)) {
             $value = $data[0];

--- a/Util/Overview/StatsAggregator.php
+++ b/Util/Overview/StatsAggregator.php
@@ -11,24 +11,10 @@ use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
  */
 class StatsAggregator
 {
-    /**
-     * @var StorageInterface
-     */
-    private $storage;
-
-    /**
-     * @var LocaleManagerInterface
-     */
-    private $localeManager;
-
-    /**
-     * @param StorageInterface       $storage
-     * @param LocaleManagerInterface $localeManager
-     */
-    public function __construct(StorageInterface $storage, LocaleManagerInterface $localeManager)
-    {
-        $this->storage = $storage;
-        $this->localeManager = $localeManager;
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly LocaleManagerInterface $localeManager,
+    ) {
     }
 
     /**
@@ -36,21 +22,20 @@ class StatsAggregator
      */
     public function getStats()
     {
-        $stats = array();
+        $stats = [];
         $countByDomains = $this->storage->getCountTransUnitByDomains();
 
         foreach ($countByDomains as $domain => $total) {
-            $stats[$domain] = array();
+            $stats[$domain] = [];
             $byLocale = $this->storage->getCountTranslationByLocales($domain);
 
             foreach ($this->localeManager->getLocales() as $locale) {
-                $localeCount = isset($byLocale[$locale]) ? $byLocale[$locale] : 0;
+                $localeCount = $byLocale[$locale] ?? 0;
 
-                $stats[$domain][$locale] = array(
-                    'keys'       => $total,
-                    'translated' => $localeCount,
-                    'completed'  => ($total > 0) ? floor(($localeCount / $total) * 100) : 0,
-                );
+                $stats[$domain][$locale] = ['keys'       => $total,
+                                            'translated' => $localeCount,
+                                            'completed'  => ($total > 0) ? floor(($localeCount / $total) * 100) : 0,
+                ];
             }
         }
 

--- a/Util/Profiler/TokenFinder.php
+++ b/Util/Profiler/TokenFinder.php
@@ -9,24 +9,10 @@ use Symfony\Component\HttpKernel\Profiler\Profiler;
  */
 class TokenFinder
 {
-    /**
-     * @var Profiler
-     */
-    private $profiler;
-
-    /**
-     * @var int
-     */
-    private $defaultLimit;
-
-    /**
-     * @param Profiler $profiler
-     * @param int      $defaultLimit
-     */
-    public function __construct(Profiler $profiler, $defaultLimit)
-    {
-        $this->profiler = $profiler;
-        $this->defaultLimit = $defaultLimit;
+    public function __construct(
+        private readonly Profiler $profiler,
+        private readonly int $defaultLimit,
+    ) {
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "symfony/framework-bundle": "~5.2|~6.0",
+        "php": "^8.1",
+        "symfony/framework-bundle": "~6.0",
         "monolog/monolog": "^3.2"
     },
     "require-dev": {
-        "symfony/symfony": "~5.0|~6.0",
+        "symfony/symfony": "~6.0",
         "ext-mongodb": "*",
         "doctrine/orm": ">=2.4",
         "doctrine/doctrine-bundle": "^2.2",
@@ -33,7 +33,8 @@
         "doctrine/mongodb-odm": "^2.1",
         "mongodb/mongodb": "^1.8",
         "ext-pdo": "*",
-        "mikey179/vfsstream": "^1.6"
+        "mikey179/vfsstream": "^1.6",
+        "rector/rector": "^0.14.8"
     },
     "suggest": {
         "doctrine/orm": ">=2.4"

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/Command',
+        __DIR__ . '/Controller',
+        __DIR__ . '/DependencyInjection',
+        __DIR__ . '/Document',
+        __DIR__ . '/Entity',
+        __DIR__ . '/EventDispatcher',
+        __DIR__ . '/Form',
+        __DIR__ . '/Manager',
+        __DIR__ . '/Model',
+        __DIR__ . '/Propel',
+        __DIR__ . '/Storage',
+        __DIR__ . '/Tests',
+        __DIR__ . '/Translation',
+        __DIR__ . '/Util',
+    ]);
+
+    // register a single rule
+    //$rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81
+    ]);
+};


### PR DESCRIPTION
This will drop support for php 7.4 and 8 and will require Symfony > 6 for master. Support for older versions can still be provided by creating PR's for older branches or by creating new branches of those.