### PR TITLE
Fix deprecations for SF6.3

### DIFF
--- a/Command/ExportTranslationsCommand.php
+++ b/Command/ExportTranslationsCommand.php
@@ -35,7 +35,7 @@ class ExportTranslationsCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lexik:translations:export');
         $this->setDescription('Export translations from the database to files.');

--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -46,7 +46,7 @@ class ImportTranslationsCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('lexik:translations:import');
         $this->setDescription('Import all translations from flat files (xliff, yml, php) into the database.');

--- a/LexikTranslationBundle.php
+++ b/LexikTranslationBundle.php
@@ -14,7 +14,7 @@ use Lexik\Bundle\TranslationBundle\DependencyInjection\Compiler\TranslatorPass;
  */
 class LexikTranslationBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 


### PR DESCRIPTION
Fix deprecation raised on Symfony 6.3 related to missing "void" return type in configure methods of commands:

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Lexik\Bundle\TranslationBundle\Command\ImportTranslationsCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Lexik\Bundle\TranslationBundle\Command\ExportTranslationsCommand" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Lexik\Bundle\TranslationBundle\LexikTranslationBundle" now to avoid errors or add an explicit @return annotation to suppress this message.

Note that the "void" return type have been introduced in PHP 8.1 so it's in line with the constraint in composer.json.