### PR TITLE
Fix SF6.3 deprecations (part2)

### DIFF
--- a/DependencyInjection/Compiler/RegisterMappingPass.php
+++ b/DependencyInjection/Compiler/RegisterMappingPass.php
@@ -17,7 +17,7 @@ class RegisterMappingPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $storage = $container->getParameter('lexik_translation.storage');
 

--- a/DependencyInjection/Compiler/TranslatorPass.php
+++ b/DependencyInjection/Compiler/TranslatorPass.php
@@ -20,7 +20,7 @@ class TranslatorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         // loaders
         $loaders = [];


### PR DESCRIPTION
Fixes the following deprecations using SF6.3:

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Lexik\Bundle\TranslationBundle\DependencyInjection\Compiler\TranslatorPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Lexik\Bundle\TranslationBundle\DependencyInjection\Compiler\RegisterMappingPass" now to avoid errors or add an explicit @return annotation to suppress this message.
