### PR TITLE
Update LexikTranslationExtension.php

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -30,7 +30,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $processor = new Processor();
         $configuration = new Configuration();
@@ -127,7 +127,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
         $container->setDefinition('lexik_translation.listener.clean_translation_cache', $listener);
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if (!$container->hasExtension('twig')) {
             return;


### PR DESCRIPTION
Fix the following deprecation on SF6.3:

Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Lexik\Bundle\TranslationBundle\DependencyInjection\LexikTranslationExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface::prepend()" might add "void" as a native return type declaration in the future. Do the same in implementation "Lexik\Bundle\TranslationBundle\DependencyInjection\LexikTranslationExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
