### PR TITLE
Fix SF63 deprecations - annotations to attributes

### DIFF
--- a/Util/Csrf/CsrfCheckerTrait.php
+++ b/Util/Csrf/CsrfCheckerTrait.php
@@ -2,9 +2,9 @@
 
 namespace Lexik\Bundle\TranslationBundle\Util\Csrf;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * Class CsrfChecker.
@@ -15,17 +15,13 @@ trait CsrfCheckerTrait
 
     private $tokenManager;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setRequestStack(RequestStack $requestStack): void
     {
         $this->requestStack = $requestStack;
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setTokenManager(?CsrfTokenManager $tokenManager): void
     {
         $this->tokenManager = $tokenManager;


### PR DESCRIPTION
SF6.3 raised the following deprecation that we can fix replacing the @required annotation by #[Required] (Symfony\Contracts\Service\Attribute\Required) attribute n top of setRequestStack and setTokenManager methods in https://github.com/lexik/LexikTranslationBundle/blob/master/Util/Csrf/CsrfCheckerTrait.php

The compatibility with lower versions should be right as the class exists since SF5.2 and this package is constraint to Symfony ~6.0 and require PHP >= 8.1. See https://symfony.com/blog/new-in-symfony-5-2-php-8-attributes

```
1x: Since symfony/dependency-injection 6.3: Relying on the "@required" annotation on method "Lexik\Bundle\TranslationBundle\Controller\RestController::setRequestStack()" is deprecated, use the "Symfony\Contracts\Service\Attribute\Required" attribute instead.
1x in DelegationControllerTest::quotaIncreaseProvideData from PTC\AdminBundle\Tests\Controller

1x: Since symfony/dependency-injection 6.3: Relying on the "@required" annotation on method "Lexik\Bundle\TranslationBundle\Controller\RestController::setTokenManager()" is deprecated, use the "Symfony\Contracts\Service\Attribute\Required" attribute instead.
1x in DelegationControllerTest::quotaIncreaseProvideData from PTC\AdminBundle\Tests\Controller

1x: Since symfony/dependency-injection 6.3: Relying on the "@required" annotation on method "Lexik\Bundle\TranslationBundle\Controller\TranslationController::setRequestStack()" is deprecated, use the "Symfony\Contracts\Service\Attribute\Required" attribute instead.
1x in DelegationControllerTest::quotaIncreaseProvideData from PTC\AdminBundle\Tests\Controller

1x: Since symfony/dependency-injection 6.3: Relying on the "@required" annotation on method "Lexik\Bundle\TranslationBundle\Controller\TranslationController::setTokenManager()" is deprecated, use the "Symfony\Contracts\Service\Attribute\Required" attribute instead.
1x in DelegationControllerTest::quotaIncreaseProvideData from PTC\AdminBundle\Tests\Controller
```

Fix https://github.com/lexik/LexikTranslationBundle/issues/437
