### PR TITLE
Fix using XML mapping driver with XSD validation disabled is deprecated

### DIFF
--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -193,7 +193,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
      */
     protected function createDoctrineMappingDriver(ContainerBuilder $container, $driverId, $driverClass)
     {
-        $driverDefinition = new Definition($driverClass, [[realpath(__DIR__.'/../Resources/config/model') => 'Lexik\Bundle\TranslationBundle\Model']]);
+        $driverDefinition = new Definition($driverClass, [[realpath(__DIR__.'/../Resources/config/model') => 'Lexik\Bundle\TranslationBundle\Model'], SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION, true]);
         $driverDefinition->setPublic(false);
 
         $container->setDefinition($driverId, $driverDefinition);

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -176,7 +176,11 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
             throw new \RuntimeException(sprintf('Unsupported storage "%s".', $storage));
         }
 
-        $args[] = ['trans_unit'  => new Parameter(sprintf('lexik_translation.%s.trans_unit.class', $storage)), 'translation' => new Parameter(sprintf('lexik_translation.%s.translation.class', $storage)), 'file'        => new Parameter(sprintf('lexik_translation.%s.file.class', $storage))];
+        $args[] = [
+            'trans_unit'  => new Parameter(sprintf('lexik_translation.%s.trans_unit.class', $storage)), 
+            'translation' => new Parameter(sprintf('lexik_translation.%s.translation.class', $storage)), 
+            'file'        => new Parameter(sprintf('lexik_translation.%s.file.class', $storage))
+        ];
 
         $storageDefinition = new Definition();
         $storageDefinition->setClass($container->getParameter(sprintf('lexik_translation.%s.translation_storage.class', $storage)));
@@ -194,7 +198,10 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
      */
     protected function createDoctrineMappingDriver(ContainerBuilder $container, $driverId, $driverClass)
     {
-        $driverDefinition = new Definition($driverClass, [[realpath(__DIR__.'/../Resources/config/model') => 'Lexik\Bundle\TranslationBundle\Model'], SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION, true]);
+        $driverDefinition = new Definition($driverClass, [
+            [realpath(__DIR__.'/../Resources/config/model') => 'Lexik\Bundle\TranslationBundle\Model'], 
+            SimplifiedXmlDriver::DEFAULT_FILE_EXTENSION, true
+        ]);
         $driverDefinition->setPublic(false);
 
         $container->setDefinition($driverId, $driverDefinition);

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\TranslationBundle\DependencyInjection;
 
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Symfony\Component\Config\FileLocator;


### PR DESCRIPTION
Fix using XML mapping driver with XSD validation disabled is deprecated and will not be supported in Doctrine ORM 3.0.

```
12x: Using XML mapping driver with XSD validation disabled is deprecated and will not be supported in Doctrine ORM 3.0. (XmlDriver.php:60 called by SimplifiedXmlDriver.php:23, https://github.com/doctrine/orm/pull/6728, package doctrine/orm)
    10x in MeetingControllerTest::testCompleteScenario from PTC\AdminBundle\Tests\Controller
    1x in MeetingControllerTest::testCalendarView from PTC\AdminBundle\Tests\Controller
    1x in MeetingControllerTest::testDeleteWarningAction from PTC\AdminBundle\Tests\Controller
```

See https://github.com/doctrine/DoctrineBundle/issues/1647

Please note that ``validate_xml_mapping`` needs to be set on ``true`` to expose the XSD validation in the DoctrineOrmMappingsPass

https://www.doctrine-project.org/projects/doctrine-bundle/en/latest/configuration.html
https://github.com/doctrine/DoctrineBundle/pull/1679