### PR TITLE
Fix return deprecation

### DIFF
--- a/Util/Doctrine/SingleColumnArrayHydrator.php
+++ b/Util/Doctrine/SingleColumnArrayHydrator.php
@@ -14,7 +14,7 @@ class SingleColumnArrayHydrator extends AbstractHydrator
     /**
      * {@inheritdoc}
      */
-    protected function hydrateAllData()
+    protected function hydrateAllData(): array
     {
         $result = [];
 

--- a/Util/Doctrine/SingleColumnArrayHydrator.php
+++ b/Util/Doctrine/SingleColumnArrayHydrator.php
@@ -18,7 +18,7 @@ class SingleColumnArrayHydrator extends AbstractHydrator
     {
         $result = [];
 
-        while ($data = $this->_stmt->fetch(\PDO::FETCH_NUM)) {
+        while ($data = $this->_stmt->fetchNumeric()) {
             $value = $data[0];
 
             if (is_numeric($value)) {


### PR DESCRIPTION
I added array return type to hydrateAllData() function to avoid deprecations related to doctrine's AbsractHydrator()