### PR TITLE
Fix Symfony 7.1+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,29 +23,29 @@
     ],
     "require": {
         "php": "^8.2",
-        "symfony/framework-bundle": "~7.0",
-        "monolog/monolog": "^3.2",
-        "doctrine/orm": "^2.4",
         "doctrine/doctrine-bundle": "^2.2",
-        "symfony/asset": "7.0.*",
-        "symfony/form": "7.0.*",
-        "symfony/security-csrf": "7.0.*",
-        "symfony/translation": "7.0.*|^5.0.0",
+        "doctrine/orm": "^2.4",
+        "monolog/monolog": "^3.2",
+        "symfony/asset": "^7.0",
+        "symfony/form": "^7.0",
+        "symfony/framework-bundle": "^7.0",
+        "symfony/security-csrf": "^7.0",
+        "symfony/translation": "^7.0",
+        "symfony/twig-bundle": "^7.0",
         "symfony/validator": "^7.0",
-        "symfony/twig-bundle": "7.0.*",
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
         "ext-mongodb": "*",
+        "ext-pdo": "*",
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.4",
-        "doctrine/data-fixtures": "~1.1",
-        "phpunit/phpunit": "^9.5",
-        "doctrine/mongodb-odm-bundle": "^2.0",
-        "doctrine/mongodb-odm": "^2.7.x-dev",
-        "mongodb/mongodb": "^1.8",
-        "ext-pdo": "*",
+        "doctrine/data-fixtures": "^1.1",
+        "doctrine/mongodb-odm": "^2.7",
+        "doctrine/mongodb-odm-bundle": "^5.0",
         "mikey179/vfsstream": "^1.6",
+        "mongodb/mongodb": "^1.8",
+        "phpunit/phpunit": "^9.5",
         "rector/rector": "^0.14.8"
     },
     "autoload": {
@@ -66,5 +66,8 @@
     "minimum-stability": "alpha",
     "scripts": {
         "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
This PR fixes compatibility with Symfony 7.1
Currently, this bundle can only be installed on Symfony 7.0

I also added the `"sort-packages": true` config option to sort composer packages.
(This config option is commonly used by most projects)