### PR TITLE
Fix returning all data when no result found

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -210,6 +210,8 @@ class TransUnitRepository extends EntityRepository
 
             if ((is_countable($ids) ? count($ids) : 0) > 0) {
                 $builder->andWhere($builder->expr()->in('tu.id', $ids));
+            } else {
+                $builder->andWhere($builder->expr()->eq(1, 0));
             }
         }
     }


### PR DESCRIPTION
This PR fix the current behavior that returns all data when the search criteria lead to no matching results. Currently if the matching ids count is 0 no where clause is added.

This PR add a clause that will never matches in that case to return no data.

With the fix when the search doesn't matches, we have an empty list:

![343191040-29dc9102-be16-40d7-b45e-a210abbfdfa7](https://github.com/lexik/LexikTranslationBundle/assets/652505/e9e7f8e4-8927-4fb6-a169-ebeeaf6fb450)
