### PR TITLE
Import files from old and new translation directory

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -224,7 +224,12 @@ class ImportTranslationsCommand extends Command
      */
     protected function importBundleTranslationFiles(BundleInterface $bundle, $locales, $domains, $global = false)
     {
-        $path = $bundle->getPath();
+        /** @var string[] **/
+        $paths = [
+            $bundle->getPath() . '/translations',
+            $bundle->getPath() . '/Resources/translations',
+        ];
+        
         if ($global) {
             $kernel = $this->getApplication()->getKernel();
             if (Kernel::MAJOR_VERSION >= 4) {
@@ -236,11 +241,14 @@ class ImportTranslationsCommand extends Command
             $path .= '/Resources/' . $bundle->getName() . '/translations';
 
             $this->output->writeln('<info>*** Importing ' . $bundle->getName() . '`s translation files from ' . $path . ' ***</info>');
+            $paths = $path;
         }
 
-        $this->output->writeln(sprintf('<info># %s:</info>', $bundle->getName()));
-        $finder = $this->findTranslationsFiles($path, $locales, $domains);
-        $this->importTranslationFiles($finder);
+        foreach($paths as $path) {
+            $this->output->writeln(sprintf('<info># %s:</info>', $bundle->getName()));
+            $finder = $this->findTranslationsFiles($path, $locales, $domains, false);
+            $this->importTranslationFiles($finder);
+        }
     }
 
     /**


### PR DESCRIPTION
Symfony bundles can have two folder hierarchies:

1. `vendor/my_vendor/my_bundle/Resources/translations`
2. `vendor/my_vendor/my_bundle/translations`

This bundle is not taking care of the new hierarchy and this avoid the translations from newest bundles to be loaded.

This PR aim to fix the issue at least during the translation import.