### PR TITLE
Fix doctrine ORM 3.0+ compatibility

### DIFF
--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -113,7 +113,7 @@ class TransUnitRepository extends EntityRepository
      *
      * @return int
      */
-    public function count(array $locales = null,  array $filters = null)
+    public function count(array $locales = null,  array $filters = null): int
     {
         $this->loadCustomHydrator();
 

--- a/Util/Doctrine/SingleColumnArrayHydrator.php
+++ b/Util/Doctrine/SingleColumnArrayHydrator.php
@@ -18,7 +18,9 @@ class SingleColumnArrayHydrator extends AbstractHydrator
     {
         $result = [];
 
-        while ($data = $this->_stmt->fetchNumeric()) {
+        $stmt = $this->_stmt ?? $this->stmt;
+
+        while ($data = $stmt->fetchNumeric()) {
             $value = $data[0];
 
             if (is_numeric($value)) {


### PR DESCRIPTION
doctrine/orm:3.x made some changes that break lexik/translation-bundle functionality.

`EntityRepository::count` got a return type: https://github.com/doctrine/orm/blob/c3cc0fdd8c9ffb102170c930ca56188626a34719/src/EntityRepository.php#L137 making the implementation of `TransUnitRepository::count` throw an error (closes #459)

`AbstractHydrator` now has a `$stmt` property instead of doctrine/orm:2.x `$_stmt`, this is used by `SingleColumnArrayHydrator`.

I've tested these changes in two projects that I've had at hand, one using doctrine/orm:3.2.2 (the permalinks I've put above are from doctrine/orm:3.0.x, though) and another one using doctrine/orm:2.20.1 - they work in both.

For testing I have ran the import, changed something in the UI, exported - it all worked as expected. Let me know if you want me to test something else.

I've also ran the phpunit tests and they all pass - but I guess travis ci will confirm it.