### PR TITLE
Update AbstractDoctrineStorage.php to fix deprecated

### DIFF
--- a/Storage/AbstractDoctrineStorage.php
+++ b/Storage/AbstractDoctrineStorage.php
@@ -154,7 +154,7 @@ abstract class AbstractDoctrineStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null)
+    public function getTransUnitList(?array $locales = null, ?int $rows = 20, ?int $page = 1, ?array $filters = null)
     {
         return $this->getTransUnitRepository()->getTransUnitList($locales, $rows, $page, $filters);
     }
@@ -162,7 +162,7 @@ abstract class AbstractDoctrineStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function countTransUnits(array $locales = null, array $filters = null)
+    public function countTransUnits(?array $locales = null, ?array $filters = null)
     {
         return $this->getTransUnitRepository()->count($locales, $filters);
     }


### PR DESCRIPTION
Fix deprecated -  Implicitly marking parameters as nullable is deprecated.