### PR TITLE
fix(Storage): Implicitly nullable parameters are deprecated

### DIFF
--- a/Entity/File.php
+++ b/Entity/File.php
@@ -16,7 +16,7 @@ class File extends FileModel implements FileInterface
     /**
      * {@inheritdoc}
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->createdAt = new \DateTime("now");
         $this->updatedAt = new \DateTime("now");
@@ -25,7 +25,7 @@ class File extends FileModel implements FileInterface
     /**
      * {@inheritdoc}
      */
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->updatedAt = new \DateTime("now");
     }

--- a/Entity/FileRepository.php
+++ b/Entity/FileRepository.php
@@ -16,7 +16,7 @@ class FileRepository extends EntityRepository
      *
      * @return array
      */
-    public function findForLocalesAndDomains(array $locales, array $domains)
+    public function findForLocalesAndDomains(array $locales, array $domains): mixed
     {
         $builder = $this->createQueryBuilder('f');
 

--- a/Entity/TransUnit.php
+++ b/Entity/TransUnit.php
@@ -18,7 +18,7 @@ class TransUnit extends TransUnitModel implements TransUnitInterface
      *
      * @param \Lexik\Bundle\TranslationBundle\Entity\Translation $translations
      */
-    public function addTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation)
+    public function addTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation): void
     {
         $translation->setTransUnit($this);
 
@@ -28,7 +28,7 @@ class TransUnit extends TransUnitModel implements TransUnitInterface
     /**
      * {@inheritdoc}
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $this->createdAt = new \DateTime("now");
         $this->updatedAt = new \DateTime("now");
@@ -37,7 +37,7 @@ class TransUnit extends TransUnitModel implements TransUnitInterface
     /**
      * {@inheritdoc}
      */
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->updatedAt = new \DateTime("now");
     }

--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -36,7 +36,7 @@ class TransUnitRepository extends EntityRepository
      *
      * @return array
      */
-    public function getAllByLocaleAndDomain($locale, $domain)
+    public function getAllByLocaleAndDomain($locale, $domain): mixed
     {
         return $this->createQueryBuilder('tu')
             ->select('tu, te')
@@ -54,7 +54,7 @@ class TransUnitRepository extends EntityRepository
      *
      * @return array
      */
-    public function getAllDomains()
+    public function getAllDomains(): mixed
     {
         $this->loadCustomHydrator();
 
@@ -72,7 +72,7 @@ class TransUnitRepository extends EntityRepository
      * @param int   $page
      * @return array
      */
-    public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null)
+    public function getTransUnitList(?array $locales = null, $rows = 20, $page = 1, ?array $filters = null): mixed
     {
         $this->loadCustomHydrator();
 
@@ -132,7 +132,7 @@ class TransUnitRepository extends EntityRepository
     /**
      * @return array
      */
-    public function countByDomains()
+    public function countByDomains(): mixed
     {
         return $this->createQueryBuilder('tu')
             ->select('COUNT(DISTINCT tu.id) AS number, tu.domain')
@@ -147,7 +147,7 @@ class TransUnitRepository extends EntityRepository
      * @param boolean   $onlyUpdated
      * @return array
      */
-    public function getTranslationsForFile(ModelFile $file, $onlyUpdated)
+    public function getTranslationsForFile(ModelFile $file, $onlyUpdated): array
     {
         $builder = $this->createQueryBuilder('tu')
             ->select('tu.key, te.content')
@@ -173,7 +173,7 @@ class TransUnitRepository extends EntityRepository
     /**
      * Add conditions according to given filters.
      */
-    protected function addTransUnitFilters(QueryBuilder $builder, array $filters = null)
+    protected function addTransUnitFilters(QueryBuilder $builder, ?array $filters = null): void
     {
         if (isset($filters['_search']) && $filters['_search']) {
             if (!empty($filters['domain'])) {
@@ -191,7 +191,7 @@ class TransUnitRepository extends EntityRepository
     /**
      * Add conditions according to given filters.
      */
-    protected function addTranslationFilter(QueryBuilder $builder, array $locales = null, array $filters = null)
+    protected function addTranslationFilter(QueryBuilder $builder, ?array $locales = null, ?array $filters = null): void
     {
         if (null !== $locales) {
             $qb = $this->createQueryBuilder('tu');
@@ -222,7 +222,7 @@ class TransUnitRepository extends EntityRepository
     /**
      * Load custom hydrator.
      */
-    protected function loadCustomHydrator()
+    protected function loadCustomHydrator(): void
     {
         $config = $this->getEntityManager()->getConfiguration();
         $config->addCustomHydrationMode('SingleColumnArrayHydrator', \Lexik\Bundle\TranslationBundle\Util\Doctrine\SingleColumnArrayHydrator::class);

--- a/Entity/Translation.php
+++ b/Entity/Translation.php
@@ -6,6 +6,7 @@ use DateTime;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Lexik\Bundle\TranslationBundle\Model\Translation as TranslationModel;
 use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
+use Lexik\Bundle\TranslationBundle\Model\TransUnit;
 
 /**
  * @UniqueEntity(fields={"transUnit", "locale"})
@@ -22,14 +23,14 @@ class Translation extends TranslationModel implements TranslationInterface
     /**
      * @var TransUnit
      */
-    protected $transUnit;
+    protected TransUnit $transUnit;
 
     /**
      * Get id
      *
      * @return integer
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -39,7 +40,7 @@ class Translation extends TranslationModel implements TranslationInterface
      *
      * @param TransUnit $transUnit
      */
-    public function setTransUnit(\Lexik\Bundle\TranslationBundle\Model\TransUnit $transUnit)
+    public function setTransUnit(TransUnit $transUnit): void
     {
         $this->transUnit = $transUnit;
     }
@@ -49,7 +50,7 @@ class Translation extends TranslationModel implements TranslationInterface
      *
      * @return TransUnit
      */
-    public function getTransUnit()
+    public function getTransUnit(): TransUnit
     {
         return $this->transUnit;
     }
@@ -57,14 +58,14 @@ class Translation extends TranslationModel implements TranslationInterface
     /**
      * {@inheritdoc}
      */
-    public function prePersist()
+    public function prePersist(): void
     {
         $now             = new DateTime("now");
         $this->createdAt = $now;
         $this->updatedAt = $now;
     }
 
-    public function preUpdate()
+    public function preUpdate(): void
     {
         $this->updatedAt = new DateTime("now");
     }

--- a/Entity/Translation.php
+++ b/Entity/Translation.php
@@ -7,7 +7,6 @@ use DateTime;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Lexik\Bundle\TranslationBundle\Model\Translation as TranslationModel;
 use Lexik\Bundle\TranslationBundle\Manager\TranslationInterface;
-use Lexik\Bundle\TranslationBundle\Model\TransUnit;
 
 /**
  * @UniqueEntity(fields={"transUnit", "locale"})

--- a/Entity/TranslationRepository.php
+++ b/Entity/TranslationRepository.php
@@ -14,7 +14,7 @@ class TranslationRepository extends EntityRepository
     /**
      * @return \DateTime|null
      */
-    public function getLatestTranslationUpdatedAt()
+    public function getLatestTranslationUpdatedAt(): \DateTime|null
     {
         $date = $this->createQueryBuilder('t')
             ->select('MAX(t.updatedAt)')
@@ -28,7 +28,7 @@ class TranslationRepository extends EntityRepository
      * @param string $domain
      * @return array
      */
-    public function countByLocales($domain)
+    public function countByLocales($domain): mixed
     {
         return $this->createQueryBuilder('t')
             ->select('COUNT(DISTINCT t.id) AS number, t.locale')

--- a/Entity/TranslationRepository.php
+++ b/Entity/TranslationRepository.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\TranslationBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
+use Datetime;
 
 /**
  * Repository for Translation entity.
@@ -12,16 +13,16 @@ use Doctrine\ORM\EntityRepository;
 class TranslationRepository extends EntityRepository
 {
     /**
-     * @return \DateTime|null
+     * @return ?DateTime
      */
-    public function getLatestTranslationUpdatedAt(): \DateTime|null
+    public function getLatestTranslationUpdatedAt(): ?DateTime
     {
         $date = $this->createQueryBuilder('t')
             ->select('MAX(t.updatedAt)')
             ->getQuery()
             ->getSingleScalarResult();
 
-        return !empty($date) ? new \DateTime($date) : null;
+        return !empty($date) ? new DateTime($date) : null;
     }
 
     /**

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -113,14 +113,14 @@ interface StorageInterface
      * @param int   $page
      * @return array
      */
-    public function getTransUnitList(array $locales = null, $rows = 20, $page = 1, array $filters = null);
+    public function getTransUnitList(?array $locales = null, $rows = 20, $page = 1, ?array $filters = null);
 
     /**
      * Count the number of trans unit.
      *
      * @return int
      */
-    public function countTransUnits(array $locales = null,  array $filters = null);
+    public function countTransUnits(?array $locales = null,  ?array $filters = null);
 
     /**
      * Returns all translations for the given file.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/yaml": "^7.0"
     },
     "require-dev": {
-        "ext-mongodb": "*",
+        "ext-mongodb": "^1.21.0 || ^2.0.0",
         "ext-pdo": "*",
         "doctrine/annotations": "^2",
         "doctrine/cache": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "doctrine/mongodb-odm": "^2.7",
         "doctrine/mongodb-odm-bundle": "^5.0",
         "mikey179/vfsstream": "^1.6",
-        "mongodb/mongodb": "^1.8",
+        "mongodb/mongodb": "^1.21.0 || ^2.0.0",
         "phpunit/phpunit": "^9.5",
         "rector/rector": "^0.14.8"
     },


### PR DESCRIPTION
In PHP 8.4 this PR fix deprecated errors like:

`Deprecated: Lexik\Bundle\TranslationBundle\Storage\StorageInterface::getTransUnitList(): Implicitly marking parameter $filters as nullable is deprecated, the explicit nullable type must be used instead`

`Deprecated: Lexik\Bundle\TranslationBundle\Entity\TransUnitRepository::addTranslationFilter(): Implicitly marking parameter $filters as nullable is deprecated, the explicit nullable type must be used instead`