### PR TITLE
feat: use rector for import naming and php 8.1 updates

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -285,7 +285,7 @@ class ImportTranslationsCommand extends Command
         }
 
         if (true === $autocompletePath) {
-            $dir = (str_starts_with($path, $this->getApplication()->getKernel()->getProjectDir() . '/Resources')) ? $path : $path . '/Resources/translations';
+            $dir = (str_starts_with((string) $path, $this->getApplication()->getKernel()->getProjectDir() . '/Resources')) ? $path : $path . '/Resources/translations';
         } else {
             $dir = $path;
         }

--- a/Controller/TranslationController.php
+++ b/Controller/TranslationController.php
@@ -22,7 +22,7 @@ class TranslationController extends AbstractController
 {
     use CsrfCheckerTrait;
 
-    public function __construct(private readonly StorageInterface $translationStorage, private readonly StatsAggregator $statsAggregator, private readonly TransUnitFormHandler $transUnitFormHandler, private readonly Translator $lexikTranslator, private readonly TranslatorInterface $translator, private readonly LocaleManagerInterface $localeManager, private readonly ?\Lexik\Bundle\TranslationBundle\Util\Profiler\TokenFinder $tokenFinder)
+    public function __construct(private readonly StorageInterface $translationStorage, private readonly StatsAggregator $statsAggregator, private readonly TransUnitFormHandler $transUnitFormHandler, private readonly Translator $lexikTranslator, private readonly TranslatorInterface $translator, private readonly LocaleManagerInterface $localeManager, private readonly ?TokenFinder $tokenFinder)
     {
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,7 +45,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                     ->beforeNormalization()
                         ->ifString()
-                        ->then(function ($value) { return array($value); })
+                        ->then(fn($value) => [$value])
                     ->end()
                 ->end()
 

--- a/DependencyInjection/LexikTranslationExtension.php
+++ b/DependencyInjection/LexikTranslationExtension.php
@@ -2,6 +2,10 @@
 
 namespace Lexik\Bundle\TranslationBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
 use Lexik\Bundle\TranslationBundle\Manager\LocaleManagerInterface;
@@ -37,7 +41,7 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
         $configuration = new Configuration();
         $config = $processor->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         // set parameters
@@ -241,20 +245,20 @@ class LexikTranslationExtension extends Extension implements PrependExtensionInt
         if ('all' === $registration['type'] || 'files' === $registration['type']) {
             $dirs = [];
 
-            if (class_exists(\Symfony\Component\Validator\Validation::class)) {
-                $r = new \ReflectionClass(\Symfony\Component\Validator\Validation::class);
+            if (class_exists(Validation::class)) {
+                $r = new \ReflectionClass(Validation::class);
 
                 $dirs[] = dirname($r->getFilename()).'/Resources/translations';
             }
 
-            if (class_exists(\Symfony\Component\Form\Form::class)) {
-                $r = new \ReflectionClass(\Symfony\Component\Form\Form::class);
+            if (class_exists(Form::class)) {
+                $r = new \ReflectionClass(Form::class);
 
                 $dirs[] = dirname($r->getFilename()).'/Resources/translations';
             }
 
-            if (class_exists(\Symfony\Component\Security\Core\Exception\AuthenticationException::class)) {
-                $r = new \ReflectionClass(\Symfony\Component\Security\Core\Exception\AuthenticationException::class);
+            if (class_exists(AuthenticationException::class)) {
+                $r = new \ReflectionClass(AuthenticationException::class);
 
                 if (is_dir($dir = dirname($r->getFilename()).'/../Resources/translations')) {
                     $dirs[] = $dir;

--- a/Entity/TransUnit.php
+++ b/Entity/TransUnit.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Entity;
 
+use Lexik\Bundle\TranslationBundle\Model\Translation;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Lexik\Bundle\TranslationBundle\Model\TransUnit as TransUnitModel;
 use Lexik\Bundle\TranslationBundle\Manager\TransUnitInterface;
@@ -18,7 +19,7 @@ class TransUnit extends TransUnitModel implements TransUnitInterface
      *
      * @param \Lexik\Bundle\TranslationBundle\Entity\Translation $translations
      */
-    public function addTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation)
+    public function addTranslation(Translation $translation)
     {
         $translation->setTransUnit($this);
 

--- a/Entity/TransUnitRepository.php
+++ b/Entity/TransUnitRepository.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Entity;
 
+use Lexik\Bundle\TranslationBundle\Util\Doctrine\SingleColumnArrayHydrator;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\EntityRepository;
@@ -225,6 +226,6 @@ class TransUnitRepository extends EntityRepository
     protected function loadCustomHydrator()
     {
         $config = $this->getEntityManager()->getConfiguration();
-        $config->addCustomHydrationMode('SingleColumnArrayHydrator', \Lexik\Bundle\TranslationBundle\Util\Doctrine\SingleColumnArrayHydrator::class);
+        $config->addCustomHydrationMode('SingleColumnArrayHydrator', SingleColumnArrayHydrator::class);
     }
 }

--- a/Entity/Translation.php
+++ b/Entity/Translation.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Entity;
 
+use Lexik\Bundle\TranslationBundle\Model\TransUnit;
 use DateTime;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Lexik\Bundle\TranslationBundle\Model\Translation as TranslationModel;
@@ -39,7 +40,7 @@ class Translation extends TranslationModel implements TranslationInterface
      *
      * @param TransUnit $transUnit
      */
-    public function setTransUnit(\Lexik\Bundle\TranslationBundle\Model\TransUnit $transUnit)
+    public function setTransUnit(TransUnit $transUnit)
     {
         $this->transUnit = $transUnit;
     }

--- a/Form/Type/TransUnitType.php
+++ b/Form/Type/TransUnitType.php
@@ -2,6 +2,10 @@
 
 namespace Lexik\Bundle\TranslationBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,14 +22,14 @@ class TransUnitType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('key', \Symfony\Component\Form\Extension\Core\Type\TextType::class, ['label' => 'translations.key']);
-        $builder->add('domain', \Symfony\Component\Form\Extension\Core\Type\ChoiceType::class, ['label'   => 'translations.domain', 'choices' => array_merge(
+        $builder->add('key', TextType::class, ['label' => 'translations.key']);
+        $builder->add('domain', ChoiceType::class, ['label'   => 'translations.domain', 'choices' => array_merge(
             array_combine($options['default_domain'], $options['default_domain']),
             array_combine($options['domains'], $options['domains'])
         )]);
-        $builder->add('translations', \Symfony\Component\Form\Extension\Core\Type\CollectionType::class, ['entry_type'     => \Lexik\Bundle\TranslationBundle\Form\Type\TranslationType::class, 'label'    => 'translations.page_title', 'required' => false, 'entry_options'  => ['data_class' => $options['translation_class']]]);
-        $builder->add('save', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, ['label' => 'translations.save']);
-        $builder->add('save_add', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, ['label' => 'translations.save_add']);
+        $builder->add('translations', CollectionType::class, ['entry_type'     => TranslationType::class, 'label'    => 'translations.page_title', 'required' => false, 'entry_options'  => ['data_class' => $options['translation_class']]]);
+        $builder->add('save', SubmitType::class, ['label' => 'translations.save']);
+        $builder->add('save_add', SubmitType::class, ['label' => 'translations.save_add']);
     }
 
     /**

--- a/Manager/TransUnitManager.php
+++ b/Manager/TransUnitManager.php
@@ -16,7 +16,7 @@ class TransUnitManager implements TransUnitManagerInterface
     public function __construct(
         private readonly StorageInterface $storage,
         private readonly FileManagerInterface $fileManager,
-        private string $kernelRootDir,
+        private readonly string $kernelRootDir,
     ) {
     }
 

--- a/Model/TransUnit.php
+++ b/Model/TransUnit.php
@@ -112,7 +112,7 @@ abstract class TransUnit
      *
      * @param \Lexik\Bundle\TranslationBundle\Model\Translation $translations
      */
-    public function addTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation)
+    public function addTranslation(Translation $translation)
     {
         $this->translations[] = $translation;
     }
@@ -122,7 +122,7 @@ abstract class TransUnit
      *
      * @param \Lexik\Bundle\TranslationBundle\Model\Translation $translations
      */
-    public function removeTranslation(\Lexik\Bundle\TranslationBundle\Model\Translation $translation)
+    public function removeTranslation(Translation $translation)
     {
         $this->translations->removeElement($translation);
     }

--- a/Storage/DoctrineORMStorage.php
+++ b/Storage/DoctrineORMStorage.php
@@ -50,7 +50,7 @@ class DoctrineORMStorage extends AbstractDoctrineStorage
 
                 $dbExists = in_array($connection->getDatabase(), $schemaManager->listDatabases());
                 $tmpConnection->close();
-            } catch (ConnectionException|\Exception $e) {
+            } catch (ConnectionException|\Exception) {
                 $dbExists = false;
             }
 

--- a/Storage/Listener/DoctrineORMListener.php
+++ b/Storage/Listener/DoctrineORMListener.php
@@ -18,7 +18,7 @@ class DoctrineORMListener
         /** @var ClassMetadataInfo $metadata */
         $metadata = $eventArgs->getClassMetadata();
 
-        if (!str_contains($metadata->getName(), 'TranslationBundle')) {
+        if (!str_contains((string) $metadata->getName(), 'TranslationBundle')) {
             return;
         }
 

--- a/Tests/Command/ImportTranslationsCommandTest.php
+++ b/Tests/Command/ImportTranslationsCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Command;
 
+use Doctrine\ORM\Tools\Console\EntityManagerProvider\SingleManagerProvider;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand;
@@ -34,7 +35,7 @@ class ImportTranslationsCommandTest extends WebTestCase
         static::$application = new Application(static::$kernel);
         /** @var EntityManager $em */
         $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
-        $emProvider = new EntityManagerProvider\SingleManagerProvider($em);
+        $emProvider = new SingleManagerProvider($em);
         $dropCommand = new DropCommand($emProvider);
         $createCommand = new CreateCommand($emProvider);
 

--- a/Tests/Fixtures/TransUnitData.php
+++ b/Tests/Fixtures/TransUnitData.php
@@ -119,7 +119,7 @@ class TransUnitData implements FixtureInterface
         if ($manager instanceof EntityManager) {
             $instance = new \Lexik\Bundle\TranslationBundle\Entity\TransUnit();
         } elseif ($manager instanceof DocumentManager) {
-            $instance = new \Lexik\Bundle\TranslationBundle\Document\TransUnit();
+            $instance = new TransUnit();
         }
 
         return $instance;
@@ -135,7 +135,7 @@ class TransUnitData implements FixtureInterface
         if ($manager instanceof EntityManager) {
             $instance = new \Lexik\Bundle\TranslationBundle\Entity\Translation();
         } elseif ($manager instanceof DocumentManager) {
-            $instance = new \Lexik\Bundle\TranslationBundle\Document\Translation();
+            $instance = new Translation();
         }
 
         return $instance;
@@ -151,7 +151,7 @@ class TransUnitData implements FixtureInterface
         if ($manager instanceof EntityManager) {
             $instance = new \Lexik\Bundle\TranslationBundle\Entity\File();
         } elseif ($manager instanceof DocumentManager) {
-            $instance = new \Lexik\Bundle\TranslationBundle\Document\File();
+            $instance = new File();
         }
 
         return $instance;

--- a/Tests/Unit/BaseUnitTestCase.php
+++ b/Tests/Unit/BaseUnitTestCase.php
@@ -161,7 +161,7 @@ abstract class BaseUnitTestCase extends TestCase
             [
                 __DIR__ . '/../../Model',
                 __DIR__ . '/../../Entity',
-            ], false, null, null, false
+            ], false, null, null
         );
 
         $config->setMetadataDriverImpl($xmlDriver);

--- a/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
+++ b/Tests/Unit/EventDispatcher/CleanTranslationCacheListenerTest.php
@@ -2,6 +2,9 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\EventDispatcher;
 
+use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Lexik\Bundle\TranslationBundle\Translation\Translator;
 use Lexik\Bundle\TranslationBundle\EventDispatcher\CleanTranslationCacheListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -37,16 +40,16 @@ class CleanTranslationCacheListenerTest extends TestCase
 
         \touch($this->tempDir . '/messages.en.yml', time() - 3600);
 
-        $storage = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Storage\StorageInterface::class)
+        $storage = $this->getMockBuilder(StorageInterface::class)
                 ->disableOriginalConstructor()
                 ->setMethods([])
                 ->getMock();
 
         $storage->expects($this->any())->method('getLatestUpdatedAt')->will($this->returnValue($date));
 
-        $container = $this->getMock(\Symfony\Component\DependencyInjection\ContainerInterface::class);
+        $container = $this->getMock(ContainerInterface::class);
 
-        $translator = $this->getMock(\Lexik\Bundle\TranslationBundle\Translation\Translator::class, [], [$container, new MessageSelector]);
+        $translator = $this->getMock(Translator::class, [], [$container, new MessageSelector]);
 
         $translator->expects($this->any())->method('removeLocalesCacheFiles')->will($this->returnValue(true));
 
@@ -68,7 +71,7 @@ class CleanTranslationCacheListenerTest extends TestCase
 
     private function getEvent(Request $request)
     {
-        return new GetResponseEvent($this->getMock(\Symfony\Component\HttpKernel\HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST);
+        return new GetResponseEvent($this->getMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
     private function countFiles($lastUpdateTime)

--- a/Tests/Unit/Translation/Loader/DatabaseLoaderTest.php
+++ b/Tests/Unit/Translation/Loader/DatabaseLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Translation\Loader;
 
+use Lexik\Bundle\TranslationBundle\Entity\TransUnit;
 use Lexik\Bundle\TranslationBundle\Translation\Loader\DatabaseLoader;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -22,7 +23,7 @@ class DatabaseLoaderTest extends BaseUnitTestCase
         $this->createSchema($em);
         $this->loadFixtures($em);
 
-        $loader = new DatabaseLoader($this->getORMStorage($em), \Lexik\Bundle\TranslationBundle\Entity\TransUnit::class);
+        $loader = new DatabaseLoader($this->getORMStorage($em), TransUnit::class);
 
         $catalogue = $loader->load(null, 'it');
         $this->assertInstanceOf(MessageCatalogue::class, $catalogue);

--- a/Tests/Unit/Util/DataGrid/DataGridRequestHandlerTest.php
+++ b/Tests/Unit/Util/DataGrid/DataGridRequestHandlerTest.php
@@ -2,6 +2,9 @@
 
 namespace Lexik\Bundle\TranslationBundle\Tests\Unit\Util\DataGrid;
 
+use Lexik\Bundle\TranslationBundle\Manager\TransUnitManager;
+use Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface;
+use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Manager\LocaleManager;
 use Lexik\Bundle\TranslationBundle\Tests\Unit\BaseUnitTestCase;
 use Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridRequestHandler;
@@ -128,7 +131,7 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
      */
     private function getReflectionMethod($name)
     {
-        $class = new \ReflectionClass(\Lexik\Bundle\TranslationBundle\Util\DataGrid\DataGridRequestHandler::class);
+        $class = new \ReflectionClass(DataGridRequestHandler::class);
         $method = $class->getMethod($name);
         $method->setAccessible(true);
 
@@ -140,15 +143,15 @@ class DataGridRequestHandlerTest extends BaseUnitTestCase
      */
     private function getDataGridRequestHandler()
     {
-        $transUnitManagerMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Manager\TransUnitManager::class)
+        $transUnitManagerMock = $this->getMockBuilder(TransUnitManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $fileManagerMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Manager\FileManagerInterface::class)
+        $fileManagerMock = $this->getMockBuilder(FileManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $storageMock = $this->getMockBuilder(\Lexik\Bundle\TranslationBundle\Storage\StorageInterface::class)
+        $storageMock = $this->getMockBuilder(StorageInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/Translation/DatabaseFreshResource.php
+++ b/Translation/DatabaseFreshResource.php
@@ -23,7 +23,7 @@ class DatabaseFreshResource implements SelfCheckingResourceInterface, \Stringabl
      */
     public function __toString(): string
     {
-        return $this->getResource();
+        return (string) $this->getResource();
     }
 
     /**

--- a/Translation/Exporter/YamlExporter.php
+++ b/Translation/Exporter/YamlExporter.php
@@ -13,7 +13,7 @@ use Symfony\Component\Yaml\Dumper;
 class YamlExporter implements ExporterInterface
 {
     public function __construct(
-        private bool $createTree = false
+        private readonly bool $createTree = false
     ) {
     }
 

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\TranslationBundle\Translation\Importer;
 
+use Symfony\Component\Finder\SplFileInfo;
 use Lexik\Bundle\TranslationBundle\Entity\Translation;
 use Lexik\Bundle\TranslationBundle\Storage\StorageInterface;
 use Lexik\Bundle\TranslationBundle\Document\TransUnit as TransUnitDocument;
@@ -57,7 +58,7 @@ class FileImporter
      * @param boolean $merge merge translations
      * @return int
      */
-    public function import(\Symfony\Component\Finder\SplFileInfo $file, $forceUpdate = false, $merge = false)
+    public function import(SplFileInfo $file, $forceUpdate = false, $merge = false)
     {
         $this->skippedKeys = [];
         $imported = 0;


### PR DESCRIPTION
Use import naming from rector and rules:

 * LongArrayToShortArrayRector
 * ClosureToArrowFunctionRector
 * NullToStrictStringFuncCallArgRector
 
 To fully support 8.1 syntax