### PR TITLE
Allow getTransUnitById to return null

### DIFF
--- a/Storage/AbstractDoctrineStorage.php
+++ b/Storage/AbstractDoctrineStorage.php
@@ -119,7 +119,7 @@ abstract class AbstractDoctrineStorage implements StorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getTransUnitById($id): TransUnitInterface
+    public function getTransUnitById($id): ?TransUnitInterface
     {
         return $this->getTransUnitRepository()->findOneById($id);
     }

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -86,16 +86,16 @@ interface StorageInterface
      * Returns a TransUnit by its id.
      *
      * @param int $id
-     * @return TransUnitInterface
+     * @return TransUnitInterface|null
      */
-    public function getTransUnitById($id): TransUnitInterface;
+    public function getTransUnitById($id): ?TransUnitInterface;
 
     /**
      * Returns a TransUnit by its key and domain.
      *
      * @param string $key
      * @param string $domain
-     * @return TransUnitInterface
+     * @return TransUnitInterface|null
      */
     public function getTransUnitByKeyAndDomain(string $key, string $domain): ?TransUnitInterface;
 


### PR DESCRIPTION
Null is a valid value, it should be allowed